### PR TITLE
Fix bugs in prompter

### DIFF
--- a/__tests__/tests/prompter/default.jest.ts
+++ b/__tests__/tests/prompter/default.jest.ts
@@ -3,9 +3,11 @@
  */
 import Prompter from '@tps/prompter';
 import { PROMPTER_QUESTIONS } from '@test/utilities/constants';
+import { SettingsFilePrompt } from '@tps/types/settings';
 
 const DEFAULT_ANSWER_TO_PROMPT = {
   testingPrompt: 'default value',
+  testingPrompt2: 'js',
 };
 
 /*
@@ -16,9 +18,20 @@ describe('[Prompter] Default:', () => {
   let prompter;
 
   beforeEach(() => {
-    prompter = new Prompter(PROMPTER_QUESTIONS, {
-      default: true,
-    });
+    prompter = new Prompter(
+      [
+        ...PROMPTER_QUESTIONS,
+        {
+          type: 'input',
+          name: 'testingPrompt2',
+          message: 'hey',
+          default: () => 'js',
+        } as unknown as SettingsFilePrompt,
+      ],
+      {
+        default: true,
+      }
+    );
   });
 
   it('should be able to use defaults option', () =>

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -15,7 +15,7 @@ export enum SettingsFilePromptType {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnswersHash = Record<string, any>;
+export type AnswersHash = Record<string, any>;
 
 export interface SettingsFilePrompt {
   name: string;
@@ -42,20 +42,26 @@ export interface SettingsFilePrompt {
     | boolean
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     | Array<any>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    | ((answers: AnswersHash) => any);
+    | DefaultFn;
 
-  validate?: (
-    input: string,
-    answers: AnswersHash
-  ) => (boolean | string) | Promise<boolean | string>;
+  validate?: ValidateFn;
 
   filter?: (input: string) => Promise<string> | string;
 
   transformer?: (input: string) => string | Promise<string>;
 
-  when?: boolean | ((answers: AnswersHash) => boolean);
+  when?: boolean | WhenFn;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DefaultFn = (answers: AnswersHash) => any;
+
+export type WhenFn = (answers: AnswersHash) => boolean;
+
+export type ValidateFn = (
+  input: string,
+  answers: AnswersHash
+) => (boolean | string) | Promise<boolean | string>;
 
 export interface SettingsFile {
   prompts: SettingsFilePrompt[];


### PR DESCRIPTION
## Bugs

- when answering prompts on the command-line or in a configuration file, Inquirer prompt functions don't have access to those answers. This causes issues when prompts on dependent on answers but they don't get answered via inquirer. 
- Prompter doesn't call default function when `default` is a function


## Changes

- Pass prompter answers to inquirer functions
- Call `default` as function when its a function

