### PR TITLE
Fix `opts` in tpsrc

### DIFF
--- a/__tests__/.tps/.tpsrc
+++ b/__tests__/.tps/.tpsrc
@@ -1,6 +1,8 @@
 {
   "testing-tpsrc": {
-    "extendedDest": "./new-path",
+    "opts": {
+      "extendedDest": "./new-path"
+    },
     "answers": {
       "test": "oh-yea"
     }

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -837,7 +837,7 @@ export class Templates {
 
     if (hasConfigObject) {
       logger.tps.info('Loading configuration: %n', templateConfig);
-      const { answers = {}, ...opts } = templateConfig;
+      const { answers = {}, opts = {} } = templateConfig;
       this.opts = defaults(opts, this.opts);
 
       if (is.object(answers) && !is.empty(answers)) {


### PR DESCRIPTION
## Description
currently `opts` in tpsrc doesn't work. It only works if you put options adjacent to answers