### PR TITLE
yargs-cli-cmd: Dont create a new folder

### DIFF
--- a/.tps/.tpsrc
+++ b/.tps/.tpsrc
@@ -1,19 +1,16 @@
 {
-  "testing": {
-    "name": "testing-config"
-  },
-  "new-test": {
-    "extendedDest": "__tests__/tests",
-    "newFolder": false
-  },
-  "yargs-cli-cmd": {
-    "opts": {
-      "newFolder": false
-    },
-    "answers": {
-      "type": "defaultExport",
-      "typescript": true,
-      "extension": "ts"
-    }
-  }
+	"testing": {
+		"name": "testing-config"
+	},
+	"new-test": {
+		"extendedDest": "__tests__/tests",
+		"newFolder": false
+	},
+	"yargs-cli-cmd": {
+		"answers": {
+			"type": "defaultExport",
+			"typescript": true,
+			"extension": "ts"
+		}
+	}
 }

--- a/.tps/yargs-cli-cmd/settings.js
+++ b/.tps/yargs-cli-cmd/settings.js
@@ -2,6 +2,9 @@
 
 /** @type {import('./../../src/types/settings').SettingsFile} */
 module.exports = {
+	opts: {
+		newFolder: false,
+	},
 	prompts: [
 		{
 			name: 'type',

--- a/docs/docs/main/templates/yargs-cli-cmd.mdx
+++ b/docs/docs/main/templates/yargs-cli-cmd.mdx
@@ -20,10 +20,12 @@ import TabItem from '@theme/TabItem';
 Create a yargs cli command module using
 [ESM syntax](https://github.com/yargs/yargs/blob/main/docs/advanced.md#example-command-hierarchy-using-indexmjs).
 
-:::info For template versions prior to 1.0.24, a new folder is created when
-generating a new instance of this template. This issue has been resolved in
-version 1.0.24. If you are using an incompatible version and wish to avoid a new
-folder being created, please refer to our guide on
+:::info
+
+For template versions prior to 1.0.24, a new folder is created when generating a
+new instance of this template. This issue has been resolved in version 1.0.24.
+If you are using an incompatible version and wish to avoid a new folder being
+created, please refer to our guide on
 [preventing new folder](/templates/docs/main/templates/yargs-cli-cmd#dont-use-a-new-folder).
 
 :::
@@ -91,8 +93,7 @@ Produces:
 ```txt
 | - cli/
 	| - commands/
-		| - publish/
-			| - publish.js
+		| - publish.js
 ```
 
 ```js title="cli/commands/publish.js"

--- a/docs/docs/main/templates/yargs-cli-cmd.mdx
+++ b/docs/docs/main/templates/yargs-cli-cmd.mdx
@@ -9,9 +9,8 @@ import TabItem from '@theme/TabItem';
 
 # yargs-cli-cmd
 
-<span className="badge badge--primary margin-left--xs">beta</span>
 <span className="badge badge--secondary margin-left--xs">
-	templates@v1.0.19
+	templates@>v1.0.19
 </span>
 
 <br />
@@ -21,12 +20,11 @@ import TabItem from '@theme/TabItem';
 Create a yargs cli command module using
 [ESM syntax](https://github.com/yargs/yargs/blob/main/docs/advanced.md#example-command-hierarchy-using-indexmjs).
 
-:::info
-
-Templates creates a new folder when creating a yargs cmd file which often is not
-the desired behavior. You can turn this off by taking a look at the
-[dont use a new folder](/templates/docs/main/templates/yargs-cli-cmd#dont-use-a-new-folder)
-example down below
+:::info For template versions prior to 1.0.24, a new folder is created when
+generating a new instance of this template. This issue has been resolved in
+version 1.0.24. If you are using an incompatible version and wish to avoid a new
+folder being created, please refer to our guide on
+[preventing new folder](/templates/docs/main/templates/yargs-cli-cmd#dont-use-a-new-folder).
 
 :::
 
@@ -41,8 +39,7 @@ tps yargs-cli-cmd path/to/dir/<cmd-name>
 ```
 
 ```txt title="Creates"
-| - <cmd-name>
-	| - <cmd-name>.js
+| - <cmd-name>.js
 ```
 
 <Example>
@@ -58,8 +55,7 @@ tps yargs-cli-cmd publish
 Produces:
 
 ```txt
-| - publish/
-	| - publish.js
+|- publish.js
 ```
 
 ```js title="publish.js"
@@ -174,17 +170,8 @@ looks something like this:
 If you want to add a new command called `list` you can run the following
 
 ```bash
-tps yargs-cli-cmd cli/commands/list --no-new-folder
+tps yargs-cli-cmd cli/commands/list
 ```
-
-:::tip
-
-Including the `--no-new-folder` option will prevent templates from creating a
-new folder. You can also explore
-[dont use a new folder](/templates/docs/main/templates/yargs-cli-cmd#dont-use-a-new-folder)
-for more details.
-
-:::
 
 You will be prompted to answer the following questions:
 
@@ -227,42 +214,6 @@ export const builder = {
 export const handler = async (argv) => {
 	// code ...
 };
-```
-
-### Dont create a new folder
-
-If you dont want your yarg cmd file in a new folder you can turn off the new
-folder option in your `.tps/tpsrc`
-
-If you havent already initialize your repo:
-
-```bash
-tps init
-```
-
-```json title=".tps/.tpsrc"
-{
-	"yargs-cli-cmd": {
-		"opts": {
-			// highlight-next-line
-			"newFolder": false
-		}
-	}
-}
-```
-
-Now when you run the following it will produce the cmd file with a new folder
-
-```bash
-tps yargs-cli-cmd publish
-```
-
-Produces:
-
-```txt
-| - <cwd>
-	// highlight-next-line
-	| - publish.js
 ```
 
 ### Set a loction for new instances
@@ -338,4 +289,47 @@ tps yargs-cli-cmd list_commands/template --no-new-folder
 			| - list.js
 			| - some-command.js
 			| - index.js
+```
+
+### Dont create a new folder
+
+:::caution
+
+Versions equal to or higher than `1.0.24` automatically support this behavior,
+requiring no additional action within this section.
+
+:::
+
+If you dont want your yarg cmd file in a new folder you can turn off the new
+folder option in your `.tps/tpsrc`
+
+If you havent already initialize your repo:
+
+```bash
+tps init
+```
+
+```json title=".tps/.tpsrc"
+{
+	"yargs-cli-cmd": {
+		"opts": {
+			// highlight-next-line
+			"newFolder": false
+		}
+	}
+}
+```
+
+Now when you run the following it will produce the cmd file with a new folder
+
+```bash
+tps yargs-cli-cmd publish
+```
+
+Produces:
+
+```txt
+| - <cwd>
+	// highlight-next-line
+	| - publish.js
 ```

--- a/docs/docs/main/templates/yargs-cli-cmd.mdx
+++ b/docs/docs/main/templates/yargs-cli-cmd.mdx
@@ -1,7 +1,3 @@
----
-sidebar_label: yargs-cli-cmd (beta)
----
-
 import { TemplateOptions } from '@site/docs/components/templateOptions';
 import { Example } from '@site/docs/components/example';
 import Tabs from '@theme/Tabs';

--- a/docs/docs/main/templates/yargs-cli-cmd.mdx
+++ b/docs/docs/main/templates/yargs-cli-cmd.mdx
@@ -239,8 +239,8 @@ lets say you have a directory structure like this
 			| - index.js
 ```
 
-If you wanted all new instances of your template to be generated in the
-`cli/commands` directory then add the following
+If you wanted all your new commands to be generated in the `cli/commands`
+directory then you can add the following to your tpsrc file.
 
 ```json title=".tps/.tpsrc"
 {
@@ -257,7 +257,7 @@ Now you can generate a new instance without passing in a path and it will be
 created in the `cli/commands` folder.
 
 ```bash
-tps yargs-cli-cmd list --no-new-folder
+tps yargs-cli-cmd list
 ```
 
 ```text
@@ -274,7 +274,7 @@ tps yargs-cli-cmd list --no-new-folder
 Want to create sub commands? Add a build path and let the magic unfold
 
 ```bash
-tps yargs-cli-cmd list_commands/template --no-new-folder
+tps yargs-cli-cmd list_commands/template
 ```
 
 ```text

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "templates-mo",
-	"version": "1.0.23",
+	"version": "1.0.24",
 	"description": "Templates is a powerful filesystem generator that aims to simplify the process of getting started with and maintaining code applications",
 	"main": "lib/templates/index.js",
 	"keywords": [


### PR DESCRIPTION
## Description

Dont create a new folder in the `yargs-cli-cmd` template. This is usually the desired behavior. Also updated template docs

<img width="1049" alt="Screenshot 2023-10-17 at 11 50 25 PM" src="https://github.com/marcellino-ornelas/templates/assets/35247622/42f70bd3-af25-46f9-8620-88f05d60ba06">

<img width="1119" alt="Screenshot 2023-10-17 at 11 50 45 PM" src="https://github.com/marcellino-ornelas/templates/assets/35247622/d128c7b1-8fb2-46d7-9f7d-ea235a524630">
