### PR TITLE
react-component: Change typescript extension (js, ts) -> (jsx, tsx)

### DIFF
--- a/.tps/react-component/settings.js
+++ b/.tps/react-component/settings.js
@@ -20,8 +20,8 @@ module.exports = {
 			tpsType: 'data',
 			message: 'What type of extension do you want for your component?',
 			default: (answers) => {
-				if (answers.typescript) return 'ts';
-				return 'js';
+				if (answers.typescript) return 'tsx';
+				return 'jsx';
 			},
 		},
 		{


### PR DESCRIPTION
# Description

Change default extension for react-component:
- js -> jsx
- ts -> tsx