### PR TITLE
Docs: Change render a template to generate instance

### DIFF
--- a/docs/docs/api/template-context.mdx
+++ b/docs/docs/api/template-context.mdx
@@ -19,7 +19,8 @@ import TabItem from '@theme/TabItem';
 Name of new instance you are rendering. When rendering two or more instances at
 the same time. The same concept as above apply's but for each path you pass in.
 
-If you render a template with no build path. Then `tps.name` will be null.
+If you generate a new instance of a template with no build path. Then `tps.name`
+will be null.
 
 <Example>
 

--- a/docs/docs/main/create-new-template/dynamic-files.mdx
+++ b/docs/docs/main/create-new-template/dynamic-files.mdx
@@ -598,7 +598,8 @@ object. For a full list, you can refer to the
 Name of new instance you are rendering. When rendering two or more instances at
 the same time. The same concept as above apply's but for each path you pass in.
 
-If you render a template with no build path. Then `tps.name` will be null.
+If you generate a new instance of a template with no build path. Then `tps.name`
+will be null.
 
 <Example>
 

--- a/docs/docs/main/create-new-template/packages.mdx
+++ b/docs/docs/main/create-new-template/packages.mdx
@@ -26,10 +26,10 @@ All packages live inside of a tps `template` folder
 ```
 
 `packages` can be named whatever you like except for one. Each `template` can
-optionally have a `default` package. Each time you render a template, TPS will
-automatically use everything inside your `default` package to build your
-template. Every other package that you want to be rendered must be specified
-when rendering the template.
+optionally have a `default` package. Each time you generate a new instance of a
+template, TPS will automatically use everything inside your `default` package to
+build your template. Every other package that you want to be rendered must be
+specified when rendering the template.
 
 Packages are used to enhance a template or add extra features when a user wants
 them. Its kind of like a conditional.
@@ -42,10 +42,10 @@ mushrooms, and etc _("our packages")_.
 
 ### Default package
 
-As mentioned before, when you render a template, all contents from the `default`
-package are automatically included. Think of this package as a central storage
-space for important things needed every time you use a template. It keeps all
-the essential elements in one place.
+As mentioned before, when you generate a new instance of a template, all
+contents from the `default` package are automatically included. Think of this
+package as a central storage space for important things needed every time you
+use a template. It keeps all the essential elements in one place.
 
 ```text title="Template"
 | - .tps/

--- a/docs/docs/main/create-new-template/templates.mdx
+++ b/docs/docs/main/create-new-template/templates.mdx
@@ -336,11 +336,11 @@ directories for both and render contents into both of them.
 
 </Example>
 
-### How to render a template
+### How to generate a new instance
 
-There are two ways on how to render a template. One is via our command line tool
-or by our `node_module` package. We wont go deep into this topic right now but
-here are some basics.
+There are two ways on how to generate a new instance of a template. One is via
+our command line tool or by our `node_module` package. We wont go deep into this
+topic right now but here are some basics.
 
 `<template-to-use>` is the name of the template you would like to use.
 


### PR DESCRIPTION
## Description

Change "render a template" to "generate a new instance of a template". This wording sounds way better.