### PR TITLE
Simplify `.tpsrc` files and merge all configurations

### DIFF
--- a/__tests__/tests/templates/rendering/core.jest.js
+++ b/__tests__/tests/templates/rendering/core.jest.js
@@ -166,15 +166,6 @@ describe('[Templates] Render Process:', () => {
 		});
 	});
 
-	it('should have correct tps path', () => {
-		const tps = new Templates('testing');
-
-		const cwd = process.cwd();
-		const expectedPath = path.join(cwd, '__tests__/.tps');
-
-		expect(tps.tpsPath).toBe(expectedPath);
-	});
-
 	it('should be able to use experimental template engine', async () => {
 		const tps = new Templates('testing-experimental-template-engine', {
 			experimentalTemplateEngine: true,

--- a/__tests__/tests/templates/rendering/core.jest.js
+++ b/__tests__/tests/templates/rendering/core.jest.js
@@ -6,7 +6,6 @@ import {
 	DirectoryNotFoundError,
 	RequiresTemplateError,
 } from '@tps/errors';
-import * as path from 'path';
 import { writeFile } from '@test/utilities/helpers';
 
 jest.mock('fs');

--- a/__tests__/tests/templates/tpsrc_v2.jest.ts
+++ b/__tests__/tests/templates/tpsrc_v2.jest.ts
@@ -180,6 +180,9 @@ testing-prompt-core:
 	});
 
 	it('should load a local tpsrc file not in a tps folder', () => {
+		// TODO: Shouldnt have to do this but there is a tpsrc file here in templates.json
+		vol.rmSync(path.join(CWD, '.tps/.tpsrc'));
+
 		// TODO: should not be in the tests folder
 		const localTpsrc = path.join(CWD, '.tpsrc');
 

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -906,7 +906,7 @@ export class Templates {
 		tpsrcfiles.reverse().forEach((tpsrc) => {
 			if (!tpsrc || tpsrc?.isEmpty) return;
 
-			logger.tps.info('Loading tpsrc from: %s', tpsrc.filepath);
+			logger.tps.info('Loading tpsrc from: %s %n', tpsrc.filepath, tpsrc);
 
 			this._loadTpsSpecificConfig(templateName, tpsrc.config);
 		});

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -903,7 +903,7 @@ export class Templates {
 			tpsrcSearchPlaces,
 		);
 
-		tpsrcfiles.forEach((tpsrc) => {
+		tpsrcfiles.reverse().forEach((tpsrc) => {
 			if (!tpsrc || tpsrc?.isEmpty) return;
 
 			logger.tps.info('Loading tpsrc from: %s', tpsrc.filepath);

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -28,6 +28,7 @@ import * as Promise from 'bluebird';
 import dot from '@tps/templates/dot';
 import templateEngine from '@tps/templates/template-engine';
 import { TemplateOptions } from '@tps/types/templates';
+import { Tpsrc } from '@tps/types/tpsrc';
 import {
 	CosmiconfigResult,
 	cosmiconfigSync,
@@ -35,7 +36,6 @@ import {
 	getDefaultSearchPlacesSync,
 } from 'cosmiconfig';
 import * as utils from './utils';
-import { Tpsrc } from '@tps/types/tpsrc';
 
 export const DEFAULT_OPTIONS: TemplateOptions = {
 	noLocalConfig: false,

--- a/src/utilities/fileSystem.ts
+++ b/src/utilities/fileSystem.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import * as findFileUp from 'find-up';
+import path from 'path';
+import { CosmiconfigResult, PublicExplorerSync } from 'cosmiconfig';
 
 /**
  * Check to see if the `path` is a valid directory
@@ -41,4 +43,44 @@ export function findUp(folder: string, cwd: string = process.cwd()) {
 	return findFileUp.sync(folder, {
 		cwd,
 	});
+}
+
+function countDirectories(filePath: string): number {
+	return filePath.split(path.sep).length - 1;
+}
+
+export function cosmiconfigAllExampleSync(
+	searchPath: string,
+	explorer: PublicExplorerSync,
+	searchPlaces: string[],
+): CosmiconfigResult[] {
+	const results = [];
+	const sortedSearchPlaces = searchPlaces.sort((a, b) => {
+		return countDirectories(b) - countDirectories(a);
+	});
+
+	function getNext(currentPath): CosmiconfigResult | null {
+		const currentResult = explorer.search(currentPath);
+
+		// if no result found, end search
+		if (!currentResult) {
+			return;
+		}
+
+		// add current result to end of array
+		results.push(currentResult);
+
+		const dir = sortedSearchPlaces.reduce((acc, next) => {
+			return acc.replace(next, '');
+		}, currentResult.filepath);
+
+		const nextPath = path.dirname(dir);
+
+		// eslint-disable-next-line consistent-return
+		return getNext(nextPath);
+	}
+
+	getNext(searchPath);
+
+	return results;
 }

--- a/src/utilities/fileSystem.ts
+++ b/src/utilities/fileSystem.ts
@@ -6,10 +6,10 @@ import { CosmiconfigResult, PublicExplorerSync } from 'cosmiconfig';
 /**
  * Check to see if the `path` is a valid directory
  */
-export function isDir(path: string): boolean {
+export function isDir(filePath: string): boolean {
 	let dir;
 	try {
-		dir = fs.lstatSync(path);
+		dir = fs.lstatSync(filePath);
 	} catch (e) {
 		return false;
 	}
@@ -19,10 +19,10 @@ export function isDir(path: string): boolean {
 /**
  * Check to see if the `path` is a valid file
  */
-export function isFile(path: string): boolean {
+export function isFile(filePath: string): boolean {
 	let file;
 	try {
-		file = fs.lstatSync(path);
+		file = fs.lstatSync(filePath);
 	} catch (e) {
 		return false;
 	}


### PR DESCRIPTION
## Description

This PR simplifies `tpsrc` file logic and allows for multiple config files to be used in the same repo. 

**simplifies `tpsrc` file logic**

This logic is simplified by eliminating the concepts of a global tpsrc file and local tpsrc file. Instead well use cosmi config to walk up the file system tree and load every single config file present all the way up until the [home directory](https://www.npmjs.com/package/cosmiconfig/v/9.0.0#stopdir)

**multiple config files**
All tpsrc files from your CWD and up will be read and merged starting with the home directory and down. This means your repos directory will override any existing global config settings