### PR TITLE
React-component: Fix issue when using snake case with names

### DIFF
--- a/.tps/react-component/default/helpers.def
+++ b/.tps/react-component/default/helpers.def
@@ -1,3 +1,3 @@
 {{{##def.componentName:
-{{= tps.u.capitalize(tps.name)}}
+{{= tps.u.pascalCase(tps.name)}}
 #}}}


### PR DESCRIPTION
## Description

Use `pascalCase` for react component name