### PR TITLE
Docs: allow dot component to only show result

### DIFF
--- a/docs/docs/components/dot/dot.module.css
+++ b/docs/docs/components/dot/dot.module.css
@@ -14,6 +14,11 @@
 	border-top-right-radius: 0;
 }
 
+.noTemplate {
+	border-top-left-radius: var(--ifm-code-border-radius);
+	border-top-right-radius: var(--ifm-code-border-radius);
+}
+
 .result [class*='codeBlockTitle'] {
 	background-color: #ebedf0;
 }

--- a/docs/docs/components/dot/dot.tsx
+++ b/docs/docs/components/dot/dot.tsx
@@ -40,6 +40,7 @@ export const Dot = ({
 
 	const resultClasses = [styles.result];
 
+	// When no template is being displayed, we need to fix top `border-radius`
 	if (!displayTemplate) {
 		resultClasses.push(styles.noTemplate);
 	}

--- a/docs/docs/components/dot/dot.tsx
+++ b/docs/docs/components/dot/dot.tsx
@@ -14,6 +14,7 @@ interface Props {
 	templateMeta: string;
 	resultMeta: string;
 	result: boolean;
+	displayTemplate: boolean;
 	lang: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	tps?: Partial<Tps>;
@@ -24,6 +25,7 @@ export const Dot = ({
 	children,
 	tps = {},
 	result = true,
+	displayTemplate = true,
 	templateMeta = '',
 	resultMeta = '',
 	lang = 'text',
@@ -36,22 +38,30 @@ export const Dot = ({
 		tps,
 	});
 
+	const resultClasses = [styles.result];
+
+	if (!displayTemplate) {
+		resultClasses.push(styles.noTemplate);
+	}
+
 	return (
 		<div>
-			<CodeBlock
-				className={styles.template}
-				showLineNumbers
-				title={templateName}
-				language={lang}
-				metastring={templateMeta}
-			>
-				{templateString}
-			</CodeBlock>
+			{displayTemplate && (
+				<CodeBlock
+					className={styles.template}
+					showLineNumbers
+					title={templateName}
+					language={lang}
+					metastring={templateMeta}
+				>
+					{templateString}
+				</CodeBlock>
+			)}
 
 			{result && (
 				<CodeBlock
 					title="Result"
-					className={styles.result}
+					className={resultClasses.join(' ')}
 					language={lang}
 					metastring={resultMeta}
 				>

--- a/docs/docs/main/create-new-template/dynamic-files.mdx
+++ b/docs/docs/main/create-new-template/dynamic-files.mdx
@@ -754,7 +754,7 @@ To explore all the available functions, check out the
 tps react-component nav
 ```
 
-<Dot tps={{name: "nav", packages: ['default']}} lang="js">
+<Dot tps={{name: "nav", packages: ['default']}} lang="js" displayTemplate={false}>
 
 ```text
 import React from react;

--- a/docs/docs/main/create-new-template/dynamic-files.mdx
+++ b/docs/docs/main/create-new-template/dynamic-files.mdx
@@ -754,7 +754,7 @@ To explore all the available functions, check out the
 tps react-component nav
 ```
 
-<Dot tps={{name: "nav", packages: ['default']}} lang="js" displayTemplate={false}>
+<Dot tps={{name: "nav", packages: ['default']}} lang="js">
 
 ```text
 import React from react;


### PR DESCRIPTION
## Description

Support displaying no template in the dot component.
 
**displayTemplate=true**
<img width="944" alt="Screenshot 2024-05-26 at 4 47 18 PM" src="https://github.com/marcellino-ornelas/templates/assets/35247622/dc126271-aafd-4235-9010-189ac572924b">


**displayTemplate=false**

<img width="945" alt="Screenshot 2024-05-26 at 4 46 02 PM" src="https://github.com/marcellino-ornelas/templates/assets/35247622/cf6f935a-dfc9-40ff-baf0-50987261c78e">
