### PR TITLE
Template Engine: fix block defs params leaving new line

### DIFF
--- a/__tests__/tests/templates/template-engine/defines.jest.js
+++ b/__tests__/tests/templates/template-engine/defines.jest.js
@@ -62,6 +62,16 @@ lino
 			expect(result).toBe(`lino`);
 		});
 
+		it('should be able to use args', () => {
+			const result = render(`\
+{{{##def.name:userName:
+{{= userName }}
+#}}}
+{{#def.name:"lino"}}`);
+
+			expect(result).toBe(`lino`);
+		});
+
 		it('should catch new line right before the end', () => {
 			const result = render(`\
 {{{##def.name:lino

--- a/src/templates/template-engine.ts
+++ b/src/templates/template-engine.ts
@@ -30,6 +30,7 @@ const doT: any = {
 		defineBlock:
 			/^[^\S\r\n]*?\{\{\{##\s*([\w\.$]+)\s*(\:|=)\n?([\s\S]+?)\n?#\}\}\}[^\S\r\n]*\n?/gm,
 		defineParams: /^\s*([\w$]+):([\s\S]+)/,
+		defineBlockParams: /^\s*([\w$]+):\n?([\s\S]+)/,
 		conditional: /\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}/g,
 		conditionalBlock:
 			/^[^\S\r\n]*?\{\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}\}[^\S\r\n]*\n?/gm,
@@ -88,8 +89,8 @@ function resolveDefs(c, block, def) {
 			}
 			if (!(code in def)) {
 				if (assign === ':') {
-					if (c.defineParams)
-						value.replace(c.defineParams, (m, param, v) => {
+					if (c.defineBlockParams)
+						value.replace(c.defineBlockParams, (m, param, v) => {
 							def[code] = { arg: param, text: v };
 						});
 					if (!(code in def)) def[code] = value;


### PR DESCRIPTION
## Description

When using params with block defs it currently leaves a new line

<img width="1707" alt="Screenshot 2024-06-03 at 6 03 17 PM" src="https://github.com/marcellino-ornelas/templates/assets/35247622/33105c29-64cd-4469-93ce-2c9f839a177f">

## Fix

Change params regex to account for new line

<img width="1704" alt="Screenshot 2024-06-03 at 6 11 09 PM" src="https://github.com/marcellino-ornelas/templates/assets/35247622/4f80e23b-4d69-4e66-bd3d-94da66fcf4b4">

