### PR TITLE
Update internal new-test template

### DIFF
--- a/.tps/new-test/default/{{= tps.name }}.jest.ts.dot
+++ b/.tps/new-test/default/{{= tps.name }}.jest.ts.dot
@@ -1,56 +1,40 @@
-{{{
-	const useTemplates = tps.answers.modules.includes('templates');
-}}}
 /*
  * Modules
  */
-{{{? tps.answers.playground }}}
-import Playground from '@test/utilities/playground';
-import { TESTING_DIR } from '@test/utilities/constants';
+{{{? tps.answers.templates }}}
+import { mkTemplate } from '@test/utilities/templates';
+import Templates from '@tps/templates';
+import { CWD } from "@tps/utilities/constants"
+import { reset, vol } from '@test/utilities/vol';
+import path from "path"
+{{{??}}}
+// import _ from '@tps/_';
 {{{?}}}
-{{{? tps.answers.modules.length}}}
-{{{~ tps.answers.modules :module:index }}}
-import {{= module === "templates" ? tps.u.capitalize(module) : module}} from '@tps/{{= module}}';
-{{{~}}}
-{{??}}
-import _ from '@tps/_';
-{{{?}}}
+{{{? tps.answers.templates }}}
 
 jest.mock('fs');
-
-/*
- * Constants
- */
-{{{? tps.answers.playground }}}
-const playground = new Playground(TESTING_DIR)
 {{{?}}}
 
-describe('[TPS] _', () => {
-	{{{? useTemplates}}}
-	let tps: Templates;
-
-	{{{?}}}
-	{{{? tps.answers.playground}}}
-	beforeAll(() => playground.create() );
-	afterAll(() => playground.destroy() );
-
-	{{{?}}}
+describe('{{= tps.utils.sentenceCase(tps.name)}}', () => {
+	{{{? tps.answers.templates }}}
 	beforeEach(() => {
-		{{{? useTemplates }}}
-		tps = new Templates('testing');
-		{{{?}}}
-		{{{? tps.answers.playground }}}
-		
-		return playground.createBox('_');
-		{{{?}}}
+		// jest.resetAllMocks();
+		reset();
 	});
+	{{{?}}}
 
 	it('should ...', async () => {
-		{{{? useTemplates && tps.answers.playground}}}
-		await tps.render(playground.box(), "App");
+		{{{? tps.answers.templates }}}
+		const templateName = "{{= tps.utils.paramCase(tps.name)}}";
+		
+		mkTemplate(templateName)
+
+		const tps = new Templates(templateName);
+		
+		await tps.render(CWD, "App");
 
 		// @ts-expect-error no types for extending jest functions
-		expect(playground.pathTo('...')).toBeFile();
+		expect(path.join(CWD, "App")).toBeDirectory();
 		{{{?}}}
 	});
 });

--- a/.tps/new-test/settings.json
+++ b/.tps/new-test/settings.json
@@ -5,25 +5,12 @@
 	},
 	"prompts": [
 		{
-			"name": "playground",
+			"name": "templates",
+			"aliases": ["t", "tps"],
 			"type": "confirm",
 			"tpsType": "data",
-			"message": "Will this test create new files in our fileSystem?",
-			"default": false
-		},
-		{
-			"name": "modules",
-			"type": "checkbox",
-			"choices": [
-				"templates",
-				"prompter",
-				"fileSystem",
-				"utilities",
-				"fileSystemTree",
-				"errors"
-			],
-			"tpsType": "data",
-			"message": "What modules do you need?"
+			"message": "Do you want to import templates?",
+			"default": true
 		}
 	]
 }


### PR DESCRIPTION
## Description

Update internal `new-test` to reflect changes made to how we render templates in tests. we now use an in memory filesystem and can create templates on the fly in unit tests vs creating new files in our repo and using nodes fs module to verify and read templates.