### PR TITLE
Prompt descriptions

### DIFF
--- a/.tps/react-component/settings.js
+++ b/.tps/react-component/settings.js
@@ -8,6 +8,7 @@ module.exports = {
 	prompts: [
 		{
 			name: 'export',
+			description: 'Type of export that will be used in your component',
 			message: 'Would you like a default export or named export?',
 			type: 'list',
 			tpsType: 'data',
@@ -17,6 +18,7 @@ module.exports = {
 		},
 		{
 			name: 'inlineDefaultExport',
+			description: 'Places export default on the same line as the component',
 			message:
 				'Would you like your default export on the same line as your component?',
 			type: 'confirm',
@@ -26,6 +28,7 @@ module.exports = {
 		},
 		{
 			name: 'functionStyle',
+			description: 'Type of function you would like to use in your component',
 			message:
 				'Would you like a arrow function or a function declaration for your component?',
 			type: 'list',
@@ -36,6 +39,7 @@ module.exports = {
 		},
 		{
 			name: 'typescript',
+			description: 'Generate the component in TypeScript',
 			aliases: ['t'],
 			type: 'confirm',
 			tpsType: 'data',
@@ -44,10 +48,11 @@ module.exports = {
 		},
 		{
 			name: 'extension',
+			description: 'Extension to use for the component file',
+			message: 'What type of extension do you want for your component?',
 			aliases: ['e', 'ext', 'extention'],
 			type: 'input',
 			tpsType: 'data',
-			message: 'What type of extension do you want for your component?',
 			default: (answers) => {
 				if (answers.typescript) return 'tsx';
 				return 'jsx';
@@ -55,14 +60,16 @@ module.exports = {
 		},
 		{
 			name: 'css',
+			description: 'Generate a css file for the component',
+			message: 'Would you like to include a css file?',
 			aliases: ['c'],
 			type: 'confirm',
 			tpsType: 'package',
-			message: 'Would you like to include a css file?',
 			default: true,
 		},
 		{
 			name: 'cssExtension',
+			description: 'Extension to use for the css file',
 			aliases: ['cssType', 'cssExt'],
 			tpsType: 'data',
 			type: 'input',
@@ -74,6 +81,7 @@ module.exports = {
 		},
 		{
 			name: 'test',
+			description: 'Generate a test file for the component',
 			type: 'confirm',
 			tpsType: 'package',
 			message: 'Would you like to include unit tests?',
@@ -81,10 +89,11 @@ module.exports = {
 		},
 		{
 			name: 'reactTestingLibrary',
-			type: 'confirm',
-			tpsType: 'data',
+			description: 'Use react testing library in the test file',
 			message:
 				'Would you like to use @testing-library/react in your test file?',
+			type: 'confirm',
+			tpsType: 'data',
 			when: (answers) => {
 				return !!answers.test;
 			},
@@ -93,6 +102,8 @@ module.exports = {
 		},
 		{
 			name: 'jestDomImport',
+			description:
+				'Add a @testing-library/jest-dom import statement to the test file',
 			type: 'confirm',
 			tpsType: 'data',
 			message: 'Would you like a @testing-library/jest-dom import?',
@@ -104,10 +115,11 @@ module.exports = {
 		},
 		{
 			name: 'testExtension',
+			description: 'Extension to use for the test file',
+			message: 'What type of test extension would you like?',
 			aliases: ['testType', 'testExt'],
 			tpsType: 'data',
 			type: 'input',
-			message: 'What type of test extension would you like?',
 			when: (answers) => {
 				return !!answers.test;
 			},
@@ -117,19 +129,21 @@ module.exports = {
 		},
 		{
 			name: 'index',
+			description: 'Generate a index file for the component',
+			message: 'Would you like to include a index file?',
 			aliases: ['i'],
 			type: 'confirm',
 			tpsType: 'package',
-			message: 'Would you like to include a index file?',
 			default: true,
 		},
 		{
 			name: 'indexExtension',
+			description: 'Extension to use for the index file',
+			message: 'What type of extension would you like for your index file?',
 			aliases: ['indexExt'],
 			tpsType: 'data',
 			type: 'input',
 			hidden: true,
-			message: 'What type of extension would you like for your index file?',
 			when: (answers) => {
 				return !!answers.index;
 			},
@@ -144,29 +158,33 @@ module.exports = {
 		},
 		{
 			name: 'indexExportPattern',
+			description: 'Type of export pattern to use for the index file',
+			message: 'What type of export pattern do you want for your index file?',
 			aliases: ['i'],
 			type: 'list',
 			tpsType: 'data',
 			hidden: true,
-			message: 'What type of export pattern do you want for your index file?',
 			choices: ['shorthand', 'explicit'],
 			default: 'shorthand',
 		},
 		{
 			name: 'component',
+			description:
+				'Element or component that will be returned in the component file',
+			message: 'What component would you like as the base component?',
 			hidden: true,
 			type: 'confirm',
 			tpsType: 'data',
-			message: 'What component would you like as the base component?',
 			default: 'div',
 		},
 		{
 			name: 'storybook',
+			description: 'Generate a storybook file for the component',
+			message: 'Would you like to include a storybook file?',
 			aliases: ['s', 'story'],
 			hidden: true,
 			type: 'confirm',
 			tpsType: 'package',
-			message: 'Would you like to include a storybook file?',
 			default: false,
 		},
 	],

--- a/docs/docs/api/settings/prompt.mdx
+++ b/docs/docs/api/settings/prompt.mdx
@@ -17,6 +17,10 @@ interface Prompt {
 	 */
 	name: string;
 	/**
+	 * Prompt description
+	 */
+	description: string;
+	/**
 	 * Message you would like to show user
 	 */
 	message: string;

--- a/docs/docs/components/templateOptions/templateOptions.tsx
+++ b/docs/docs/components/templateOptions/templateOptions.tsx
@@ -62,7 +62,7 @@ export const TemplateOptions = ({ template, type = 'json' }: Props) => {
 						<tr key={prompt.name}>
 							<td>{prompt.name}</td>
 							<td>
-								{prompt.message}
+								{prompt.description || prompt.message}
 								<br />
 								<span style={{ color: 'grey' }}>
 									{!!prompt?.choices?.length &&

--- a/src/prompter/prompt.ts
+++ b/src/prompter/prompt.ts
@@ -15,6 +15,8 @@ export default class Prompt {
 
 	public message: SettingsFilePrompt['message'];
 
+	public description: SettingsFilePrompt['description'];
+
 	public aliases: SettingsFilePrompt['aliases'];
 
 	public tpsType: SettingsFilePrompt['tpsType'];
@@ -56,6 +58,7 @@ export default class Prompt {
 		this.name = prompt.name;
 		this.type = prompt.type;
 		this.message = prompt.message;
+		this.description = prompt.description;
 
 		// let defaultValue;
 		// const isPrompterDefaultIndex = ['list', 'rawlist', 'expand'].includes(

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -35,6 +35,8 @@ export interface SettingsFilePrompt {
 
 	message: string;
 
+	description?: string;
+
 	tpsType: keyof typeof SettingsFilePromptTpsType;
 
 	type: keyof typeof SettingsFilePromptType;


### PR DESCRIPTION
## Description

Add description property to prompts. This property will be used in the template options and eventually in a `help` command for the cli. 

Added descriptions to react component prompts

<img width="1044" alt="Screenshot 2024-08-11 at 11 22 46 PM" src="https://github.com/user-attachments/assets/39361494-c838-402b-9fcd-7f05d9587c9f">

