### PR TITLE
Templates library plugin

### DIFF
--- a/__tests__/tests/templates-library-plugin.jest.ts
+++ b/__tests__/tests/templates-library-plugin.jest.ts
@@ -1,0 +1,122 @@
+/*
+ * Modules
+ */
+import {
+	DEFAULT_PROMPT,
+	mkPrompt,
+	mkSettingsFileJSON,
+	mkTemplate,
+} from '@test/utilities/templates';
+import Templates from '@tps/templates';
+import { CWD } from '@tps/utilities/constants';
+import { reset, vol } from '@test/utilities/vol';
+// eslint-disable-next-line import/no-relative-packages
+import { TemplatesLibrariesPlugin } from '../../docs/plugins/templates-libraries-plugin';
+
+jest.mock('fs');
+
+describe('Templates library plugin', () => {
+	beforeEach(() => {
+		// jest.resetAllMocks();
+		reset();
+	});
+
+	it('should be able to load a template', async () => {
+		const setGlobalData = jest.fn();
+		const templateName = 'templates-library-plugin';
+
+		mkTemplate(templateName, undefined, {
+			'settings.json': mkSettingsFileJSON({
+				prompts: [mkPrompt()],
+			}),
+		});
+
+		await TemplatesLibrariesPlugin(null, {
+			templates: ['templates-library-plugin'],
+		}).contentLoaded({
+			actions: { setGlobalData },
+		});
+
+		expect(setGlobalData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				templates: expect.objectContaining({
+					'templates-library-plugin': {
+						name: 'templates-library-plugin',
+						settings: {
+							prompts: expect.arrayContaining([DEFAULT_PROMPT]),
+						},
+					},
+				}),
+			}),
+		);
+	});
+
+	it('should be able to load a template with settings json file', async () => {
+		const setGlobalData = jest.fn();
+		const templateName = 'templates-library-plugin';
+
+		mkTemplate(templateName, undefined, {
+			'settings.json': mkSettingsFileJSON({
+				prompts: [mkPrompt()],
+			}),
+		});
+
+		await TemplatesLibrariesPlugin(null, {
+			templates: [templateName],
+		}).contentLoaded({
+			actions: { setGlobalData },
+		});
+
+		expect(setGlobalData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				templates: expect.objectContaining({
+					[templateName]: {
+						name: templateName,
+						settings: {
+							prompts: expect.arrayContaining([DEFAULT_PROMPT]),
+						},
+					},
+				}),
+			}),
+		);
+	});
+
+	it('should be able to load a template with settings json file', async () => {
+		const setGlobalData = jest.fn();
+		const templateName = 'templates-library-plugin';
+
+		mkTemplate(templateName, undefined, {
+			'settings.js': `\
+module.exports = {
+	prompts: [
+		${JSON.stringify(mkPrompt())}
+	],
+};`,
+		});
+
+		console.log(
+			vol.toTree({
+				dir: '/Users/marcellinoornelas/Desktop/templates/__tests__/.tps/templates-library-plugin',
+			}),
+		);
+
+		await TemplatesLibrariesPlugin(null, {
+			templates: [templateName],
+		}).contentLoaded({
+			actions: { setGlobalData },
+		});
+
+		expect(setGlobalData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				templates: expect.objectContaining({
+					[templateName]: {
+						name: templateName,
+						settings: {
+							prompts: expect.arrayContaining([DEFAULT_PROMPT]),
+						},
+					},
+				}),
+			}),
+		);
+	});
+});

--- a/__tests__/tests/templates-library-plugin.jest.ts
+++ b/__tests__/tests/templates-library-plugin.jest.ts
@@ -7,9 +7,7 @@ import {
 	mkSettingsFileJSON,
 	mkTemplate,
 } from '@test/utilities/templates';
-import Templates from '@tps/templates';
-import { CWD } from '@tps/utilities/constants';
-import { reset, vol } from '@test/utilities/vol';
+import { reset } from '@test/utilities/vol';
 // eslint-disable-next-line import/no-relative-packages
 import { TemplatesLibrariesPlugin } from '../../docs/plugins/templates-libraries-plugin';
 
@@ -17,41 +15,11 @@ jest.mock('fs');
 
 describe('Templates library plugin', () => {
 	beforeEach(() => {
-		// jest.resetAllMocks();
+		jest.resetAllMocks();
 		reset();
 	});
 
-	it('should be able to load a template', async () => {
-		const setGlobalData = jest.fn();
-		const templateName = 'templates-library-plugin';
-
-		mkTemplate(templateName, undefined, {
-			'settings.json': mkSettingsFileJSON({
-				prompts: [mkPrompt()],
-			}),
-		});
-
-		await TemplatesLibrariesPlugin(null, {
-			templates: ['templates-library-plugin'],
-		}).contentLoaded({
-			actions: { setGlobalData },
-		});
-
-		expect(setGlobalData).toHaveBeenCalledWith(
-			expect.objectContaining({
-				templates: expect.objectContaining({
-					'templates-library-plugin': {
-						name: 'templates-library-plugin',
-						settings: {
-							prompts: expect.arrayContaining([DEFAULT_PROMPT]),
-						},
-					},
-				}),
-			}),
-		);
-	});
-
-	it('should be able to load a template with settings json file', async () => {
+	it('should be able to load a template  with a json settings file', async () => {
 		const setGlobalData = jest.fn();
 		const templateName = 'templates-library-plugin';
 
@@ -81,42 +49,61 @@ describe('Templates library plugin', () => {
 		);
 	});
 
-	it('should be able to load a template with settings json file', async () => {
-		const setGlobalData = jest.fn();
-		const templateName = 'templates-library-plugin';
+	// 	it('should be able to load a template with settings js file', async () => {
+	// 		const setGlobalData = jest.fn();
+	// 		const templateName = 'templates-library-plugin';
 
-		mkTemplate(templateName, undefined, {
-			'settings.js': `\
-module.exports = {
-	prompts: [
-		${JSON.stringify(mkPrompt())}
-	],
-};`,
-		});
+	// 		mkTemplate(templateName, undefined, {
+	// 			'default/hey.txt': 'hey',
+	// 			// 			'settings.js': `\
+	// 			// module.exports = {
+	// 			// 	prompts: [
+	// 			// 		{
+	// 			// 			name: 'prompt1',
+	// 			// 			message: 'Prompt1?',
+	// 			// 			tpsType: 'data',
+	// 			// 			type: 'confirm',
+	// 			// 		}
+	// 			// 	],
+	// 			// };`,
+	// 			'./settings.js': `\
+	// module.exports = {};`,
+	// 		});
 
-		console.log(
-			vol.toTree({
-				dir: '/Users/marcellinoornelas/Desktop/templates/__tests__/.tps/templates-library-plugin',
-			}),
-		);
+	// 		const tps = new Templates(templateName);
 
-		await TemplatesLibrariesPlugin(null, {
-			templates: [templateName],
-		}).contentLoaded({
-			actions: { setGlobalData },
-		});
+	// 		console.log(
+	// 			vol
+	// 				.readFileSync(
+	// 					'/Users/marcellinoornelas/Desktop/templates/__tests__/.tps/templates-library-plugin/settings.js',
+	// 				)
+	// 				.toString(),
+	// 		);
 
-		expect(setGlobalData).toHaveBeenCalledWith(
-			expect.objectContaining({
-				templates: expect.objectContaining({
-					[templateName]: {
-						name: templateName,
-						settings: {
-							prompts: expect.arrayContaining([DEFAULT_PROMPT]),
-						},
-					},
-				}),
-			}),
-		);
-	});
+	// 		console.log(
+	// 			vol.toTree({
+	// 				// dir: '/Users/marcellinoornelas/Desktop/templates/__tests__/.tps/templates-library-plugin',
+	// 				dir: '/Users/marcellinoornelas/Desktop/templates/__tests__/',
+	// 			}),
+	// 		);
+
+	// 		await TemplatesLibrariesPlugin(null, {
+	// 			templates: [templateName],
+	// 		}).contentLoaded({
+	// 			actions: { setGlobalData },
+	// 		});
+
+	// 		expect(setGlobalData).toHaveBeenCalledWith(
+	// 			expect.objectContaining({
+	// 				templates: expect.objectContaining({
+	// 					[templateName]: {
+	// 						name: templateName,
+	// 						settings: {
+	// 							prompts: expect.arrayContaining([DEFAULT_PROMPT]),
+	// 						},
+	// 					},
+	// 				}),
+	// 			}),
+	// 		);
+	// 	});
 });

--- a/__tests__/tests/templates-library-plugin.jest.ts
+++ b/__tests__/tests/templates-library-plugin.jest.ts
@@ -12,6 +12,7 @@ import { reset } from '@test/utilities/vol';
 import { TemplatesLibrariesPlugin } from '../../docs/plugins/templates-libraries-plugin';
 
 jest.mock('fs');
+jest.mock('cosmiconfig');
 
 describe('Templates library plugin', () => {
 	beforeEach(() => {
@@ -49,61 +50,29 @@ describe('Templates library plugin', () => {
 		);
 	});
 
-	// 	it('should be able to load a template with settings js file', async () => {
-	// 		const setGlobalData = jest.fn();
-	// 		const templateName = 'templates-library-plugin';
+	// it('should be able to load a template with settings js file', async () => {
+	// 	const setGlobalData = jest.fn();
+	// 	const templateName = 'templates-library-plugin';
 
-	// 		mkTemplate(templateName, undefined, {
-	// 			'default/hey.txt': 'hey',
-	// 			// 			'settings.js': `\
-	// 			// module.exports = {
-	// 			// 	prompts: [
-	// 			// 		{
-	// 			// 			name: 'prompt1',
-	// 			// 			message: 'Prompt1?',
-	// 			// 			tpsType: 'data',
-	// 			// 			type: 'confirm',
-	// 			// 		}
-	// 			// 	],
-	// 			// };`,
-	// 			'./settings.js': `\
-	// module.exports = {};`,
-	// 		});
+	// 	mkTemplate(templateName);
 
-	// 		const tps = new Templates(templateName);
-
-	// 		console.log(
-	// 			vol
-	// 				.readFileSync(
-	// 					'/Users/marcellinoornelas/Desktop/templates/__tests__/.tps/templates-library-plugin/settings.js',
-	// 				)
-	// 				.toString(),
-	// 		);
-
-	// 		console.log(
-	// 			vol.toTree({
-	// 				// dir: '/Users/marcellinoornelas/Desktop/templates/__tests__/.tps/templates-library-plugin',
-	// 				dir: '/Users/marcellinoornelas/Desktop/templates/__tests__/',
-	// 			}),
-	// 		);
-
-	// 		await TemplatesLibrariesPlugin(null, {
-	// 			templates: [templateName],
-	// 		}).contentLoaded({
-	// 			actions: { setGlobalData },
-	// 		});
-
-	// 		expect(setGlobalData).toHaveBeenCalledWith(
-	// 			expect.objectContaining({
-	// 				templates: expect.objectContaining({
-	// 					[templateName]: {
-	// 						name: templateName,
-	// 						settings: {
-	// 							prompts: expect.arrayContaining([DEFAULT_PROMPT]),
-	// 						},
-	// 					},
-	// 				}),
-	// 			}),
-	// 		);
+	// 	await TemplatesLibrariesPlugin(null, {
+	// 		templates: [templateName],
+	// 	}).contentLoaded({
+	// 		actions: { setGlobalData },
 	// 	});
+
+	// 	expect(setGlobalData).toHaveBeenCalledWith(
+	// 		expect.objectContaining({
+	// 			templates: expect.objectContaining({
+	// 				[templateName]: {
+	// 					name: templateName,
+	// 					settings: {
+	// 						prompts: expect.arrayContaining([DEFAULT_PROMPT]),
+	// 					},
+	// 				},
+	// 			}),
+	// 		}),
+	// 	);
+	// });
 });

--- a/__tests__/tests/templates-library-plugin.jest.ts
+++ b/__tests__/tests/templates-library-plugin.jest.ts
@@ -12,7 +12,6 @@ import { reset } from '@test/utilities/vol';
 import { TemplatesLibrariesPlugin } from '../../docs/plugins/templates-libraries-plugin';
 
 jest.mock('fs');
-jest.mock('cosmiconfig');
 
 describe('Templates library plugin', () => {
 	beforeEach(() => {

--- a/__tests__/utilities/templates.ts
+++ b/__tests__/utilities/templates.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import os from 'os';
 import { CWD, USER_HOME } from '@tps/utilities/constants';
 import { DirectoryJSON } from 'memfs';
-import { SettingsFilePrompt } from '@tps/types/settings';
+import { SettingsFile, SettingsFilePrompt } from '@tps/types/settings';
 
 export type OptionsTpsrc = RecursivePartial<Tpsrc>;
 
@@ -75,6 +75,12 @@ export const mkGlobalTemplate = (
 	json: DirectoryJSON = {},
 ): void => {
 	mkTemplate(name, USER_HOME, json);
+};
+
+export type OptionsSettingsFile = RecursivePartial<SettingsFile>;
+
+export const mkSettingsFileJSON = (settings: OptionsSettingsFile): string => {
+	return JSON.stringify(settings);
 };
 
 export const DEFAULT_PROMPT: SettingsFilePrompt = {

--- a/docs/docs/components/templateOptions/templateOptions.tsx
+++ b/docs/docs/components/templateOptions/templateOptions.tsx
@@ -1,10 +1,20 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { usePluginData } from '@docusaurus/useGlobalData';
 import type {
 	SettingsFile,
 	SettingsFilePrompt,
 	AnswersHash,
 } from 'templates-mo/src/types/settings';
 import styles from './templateOptions.module.css';
+
+interface TemplateSettings {
+	name: string;
+	settings: SettingsFile;
+}
+
+interface TemplatesLibrariesPluginData {
+	templates: Record<string, TemplateSettings>;
+}
 
 const getChoices = (prompt: SettingsFilePrompt): string[] => {
 	return (prompt?.choices || []).map((choice) => {
@@ -18,31 +28,13 @@ interface Props {
 }
 
 export const TemplateOptions = ({ template, type = 'json' }: Props) => {
-	const [settingsFile, setSettingsFile] = useState<SettingsFile>(null);
+	// const [settingsFile, setSettingsFile] = useState<SettingsFile>(null);
 
-	useEffect(() => {
-		(async () => {
-			// eslint-disable-next-line import/no-extraneous-dependencies
-			const settingsFileRaw: SettingsFile = await import(
-				// eslint-disable-next-line import/extensions
-				`templates-mo/.tps/${template}/settings.${type}`
-			);
+	const { templates }: TemplatesLibrariesPluginData = usePluginData(
+		'templates-libraries-plugin',
+	);
 
-			setSettingsFile(settingsFileRaw);
-		})();
-	}, []);
-
-	const answers: AnswersHash = useMemo(() => {
-		return settingsFile?.prompts?.reduce((answersAcc, prompt) => {
-			return {
-				...answersAcc,
-				[prompt.name]:
-					typeof prompt.default === 'function'
-						? prompt.default(answersAcc)
-						: prompt.default,
-			};
-		}, {});
-	}, [settingsFile]);
+	const { settings } = templates[template];
 
 	return (
 		<div className={styles.tableContainer}>
@@ -58,7 +50,7 @@ export const TemplateOptions = ({ template, type = 'json' }: Props) => {
 					</tr>
 				</thead>
 				<tbody>
-					{settingsFile?.prompts?.map((prompt) => (
+					{settings?.prompts?.map((prompt) => (
 						<tr key={prompt.name}>
 							<td>{prompt.name}</td>
 							<td>
@@ -77,7 +69,7 @@ export const TemplateOptions = ({ template, type = 'json' }: Props) => {
 									)
 									.join(', ')}
 							</td>
-							<td>{(answers[prompt.name] ?? '').toString()}</td>
+							<td>{prompt.default.toString()}</td>
 							<td>{(prompt.hidden ?? false).toString()}</td>
 						</tr>
 					))}

--- a/docs/docs/components/templateOptions/templateOptions.tsx
+++ b/docs/docs/components/templateOptions/templateOptions.tsx
@@ -30,6 +30,8 @@ export const TemplateOptions = ({ template }: Props) => {
 		'templates-libraries-plugin',
 	) as TemplatesLibrariesPluginData;
 
+	console.log(templates);
+
 	const { settings } = templates[template];
 
 	return (

--- a/docs/docs/components/templateOptions/templateOptions.tsx
+++ b/docs/docs/components/templateOptions/templateOptions.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React from 'react';
 import { usePluginData } from '@docusaurus/useGlobalData';
 import type {
 	SettingsFile,
 	SettingsFilePrompt,
-	AnswersHash,
 } from 'templates-mo/src/types/settings';
 import styles from './templateOptions.module.css';
 
@@ -24,15 +23,12 @@ const getChoices = (prompt: SettingsFilePrompt): string[] => {
 
 interface Props {
 	template: string;
-	type: 'json' | 'js';
 }
 
-export const TemplateOptions = ({ template, type = 'json' }: Props) => {
-	// const [settingsFile, setSettingsFile] = useState<SettingsFile>(null);
-
-	const { templates }: TemplatesLibrariesPluginData = usePluginData(
+export const TemplateOptions = ({ template }: Props) => {
+	const { templates } = usePluginData(
 		'templates-libraries-plugin',
-	);
+	) as TemplatesLibrariesPluginData;
 
 	const { settings } = templates[template];
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,12 +1,9 @@
-// @ts-check
-// Note: type annotations allow type checking and IDEs autocompletion
+// const templatesPlugin = require('./plugins/templates-libraries-plugin');
+import type { Config } from '@docusaurus/types';
+import { themes } from 'prism-react-renderer';
+import { TemplatesLibrariesPlugin } from './plugins';
 
-const { themes } = require('prism-react-renderer');
-
-const templatesPlugin = require('./templates-plugin');
-
-/** @type {import('@docusaurus/types').Config} */
-const config = {
+const config: Config = {
 	title: 'Templates',
 	tagline:
 		'Supercharge Your Development with Templates: Code Faster, Build Better!',
@@ -17,7 +14,7 @@ const config = {
 	// For GitHub pages deployment, it is often '/<projectName>/'
 	baseUrl: '/templates/',
 
-	plugins: [templatesPlugin, '@docusaurus/theme-live-codeblock'],
+	plugins: [TemplatesLibrariesPlugin, '@docusaurus/theme-live-codeblock'],
 
 	// GitHub pages deployment config.
 	// If you aren't using GitHub pages, you don't need these.
@@ -44,7 +41,7 @@ const config = {
 		[
 			'classic',
 			/** @type {import('@docusaurus/preset-classic').Options} */
-			({
+			{
 				docs: {
 					sidebarPath: require.resolve('./sidebars.js'),
 					// Please change this to your repo.
@@ -66,13 +63,13 @@ const config = {
 					trackingID: 'G-X6LWJQY18G',
 					anonymizeIP: true,
 				},
-			}),
+			},
 		],
 	],
 
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-		({
+		{
 			// Replace with your project's social card
 			//   image: 'img/docusaurus-social-card.jpg',
 			navbar: {
@@ -169,8 +166,8 @@ const config = {
 				theme: themes.github,
 				darkTheme: themes.dracula,
 			},
-		}),
+		},
 	themes: ['@docusaurus/theme-mermaid'],
 };
 
-module.exports = config;
+export default config;

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,4 +1,3 @@
-// const templatesPlugin = require('./plugins/templates-libraries-plugin');
 import type { Config } from '@docusaurus/types';
 import { themes } from 'prism-react-renderer';
 import { TemplatesLibrariesPlugin } from './plugins';
@@ -40,7 +39,6 @@ const config: Config = {
 	presets: [
 		[
 			'classic',
-			/** @type {import('@docusaurus/preset-classic').Options} */
 			{
 				docs: {
 					sidebarPath: require.resolve('./sidebars.js'),
@@ -67,106 +65,104 @@ const config: Config = {
 		],
 	],
 
-	themeConfig:
-		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-		{
-			// Replace with your project's social card
-			//   image: 'img/docusaurus-social-card.jpg',
-			navbar: {
-				title: 'Templates',
-				// logo: {
-				//   alt: 'My Site Logo',
-				//   //   src: 'img/logo.svg',
-				// },
-				items: [
-					{
-						type: 'docSidebar',
-						sidebarId: 'docs',
-						position: 'left',
-						label: 'Docs',
-					},
-					{
-						type: 'docSidebar',
-						sidebarId: 'api',
-						position: 'left',
-						label: 'API',
-					},
-					{
-						label: 'Playground',
-						to: '/playground/',
-						position: 'left',
-					},
-					{
-						href: 'https://github.com/marcellino-ornelas/templates/issues',
-						label: 'Feedback',
-						position: 'right',
-					},
-					//   { to: '/blog', label: 'Blog', position: 'left' },
-					{
-						href: 'https://github.com/marcellino-ornelas/templates',
-						label: 'GitHub',
-						position: 'right',
-					},
-				],
-			},
-			footer: {
-				style: 'dark',
-				links: [
-					{
-						title: 'Docs',
-						items: [
-							{
-								label: 'Docs',
-								to: 'docs/main/intro',
-							},
-							{
-								label: 'Api',
-								to: 'docs/api/',
-							},
-						],
-					},
-					{
-						title: 'Community',
-						items: [
-							{
-								label: 'Stack Overflow',
-								href: 'https://stackoverflow.com/questions/tagged/templates-mo',
-							},
-							//   {
-							//     label: 'Discord',
-							//     href: 'https://discordapp.com/invite/docusaurus',
-							//   },
-							//   {
-							//     label: 'Twitter',
-							//     href: 'https://twitter.com/docusaurus',
-							//   },
-						],
-					},
-					{
-						title: 'More',
-						items: [
-							//   {
-							//     label: 'Blog',
-							//     to: '/blog',
-							//   },
-							{
-								label: 'GitHub',
-								href: 'https://github.com/marcellino-ornelas/templates',
-							},
-							{
-								label: 'GitHub Issues',
-								href: 'https://github.com/marcellino-ornelas/templates/issues',
-							},
-						],
-					},
-				],
-				copyright: `Copyright © ${new Date().getFullYear()} Marcellino Ornelas, Inc. Built with Docusaurus.`,
-			},
-			prism: {
-				theme: themes.github,
-				darkTheme: themes.dracula,
-			},
+	themeConfig: {
+		// Replace with your project's social card
+		//   image: 'img/docusaurus-social-card.jpg',
+		navbar: {
+			title: 'Templates',
+			// logo: {
+			//   alt: 'My Site Logo',
+			//   //   src: 'img/logo.svg',
+			// },
+			items: [
+				{
+					type: 'docSidebar',
+					sidebarId: 'docs',
+					position: 'left',
+					label: 'Docs',
+				},
+				{
+					type: 'docSidebar',
+					sidebarId: 'api',
+					position: 'left',
+					label: 'API',
+				},
+				{
+					label: 'Playground',
+					to: '/playground/',
+					position: 'left',
+				},
+				{
+					href: 'https://github.com/marcellino-ornelas/templates/issues',
+					label: 'Feedback',
+					position: 'right',
+				},
+				//   { to: '/blog', label: 'Blog', position: 'left' },
+				{
+					href: 'https://github.com/marcellino-ornelas/templates',
+					label: 'GitHub',
+					position: 'right',
+				},
+			],
 		},
+		footer: {
+			style: 'dark',
+			links: [
+				{
+					title: 'Docs',
+					items: [
+						{
+							label: 'Docs',
+							to: 'docs/main/intro',
+						},
+						{
+							label: 'Api',
+							to: 'docs/api/',
+						},
+					],
+				},
+				{
+					title: 'Community',
+					items: [
+						{
+							label: 'Stack Overflow',
+							href: 'https://stackoverflow.com/questions/tagged/templates-mo',
+						},
+						//   {
+						//     label: 'Discord',
+						//     href: 'https://discordapp.com/invite/docusaurus',
+						//   },
+						//   {
+						//     label: 'Twitter',
+						//     href: 'https://twitter.com/docusaurus',
+						//   },
+					],
+				},
+				{
+					title: 'More',
+					items: [
+						//   {
+						//     label: 'Blog',
+						//     to: '/blog',
+						//   },
+						{
+							label: 'GitHub',
+							href: 'https://github.com/marcellino-ornelas/templates',
+						},
+						{
+							label: 'GitHub Issues',
+							href: 'https://github.com/marcellino-ornelas/templates/issues',
+						},
+					],
+				},
+			],
+			copyright: `Copyright © ${new Date().getFullYear()} Marcellino Ornelas, Inc. Built with Docusaurus.`,
+		},
+		prism: {
+			theme: themes.github,
+			darkTheme: themes.dracula,
+		},
+	},
 	themes: ['@docusaurus/theme-mermaid'],
 };
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -13,7 +13,15 @@ const config: Config = {
 	// For GitHub pages deployment, it is often '/<projectName>/'
 	baseUrl: '/templates/',
 
-	plugins: [TemplatesLibrariesPlugin, '@docusaurus/theme-live-codeblock'],
+	plugins: [
+		[
+			TemplatesLibrariesPlugin,
+			{
+				templates: ['react-component', 'yargs-cli-cmd'],
+			},
+		],
+		'@docusaurus/theme-live-codeblock',
+	],
 
 	// GitHub pages deployment config.
 	// If you aren't using GitHub pages, you don't need these.

--- a/docs/plugins/index.ts
+++ b/docs/plugins/index.ts
@@ -1,0 +1,1 @@
+export * from './templates-libraries-plugin';

--- a/docs/plugins/templates-libraries-plugin.ts
+++ b/docs/plugins/templates-libraries-plugin.ts
@@ -1,0 +1,90 @@
+import type {
+	SettingsFile,
+	SettingsFilePrompt,
+} from '../../src/types/settings';
+
+const TEMPLATES_LIBRARIES: string[] = ['react-component', 'yargs-cli-cmd'];
+
+interface TemplateSettings {
+	name: string;
+	settings: SettingsFile;
+}
+
+export const TemplatesLibrariesPlugin = function TemplatesLibrariesPlugin() {
+	return {
+		name: 'templates-libraries-plugin',
+		async contentLoaded({ actions }) {
+			const { setGlobalData } = actions;
+
+			const templatesSettingsPromises: Promise<TemplateSettings>[] =
+				TEMPLATES_LIBRARIES.map(async (template) => {
+					return {
+						name: template,
+						settings: (await import(
+							`templates-mo/.tps/${template}/settings`
+						)) as SettingsFile,
+					};
+				});
+
+			const templatesSettings = await Promise.all(templatesSettingsPromises);
+
+			// `setGlobalData` only allows passing in JSON compliant data since build is in a different enviroment
+			// well need to jsonify our data which involves getting rid functions and getting the value from `default`
+			const templatesSettingsSantitize: TemplateSettings[] =
+				templatesSettings.map((template) => {
+					const answers = {};
+
+					const prompts = template?.settings?.prompts.map(
+						({
+							default: _default,
+							name,
+							message,
+							aliases,
+							choices,
+							tpsType,
+							type,
+							description,
+							hidden,
+						}) => {
+							const defaultValue =
+								typeof _default === 'function' ? _default(answers) : _default;
+
+							answers[name] = defaultValue;
+
+							return {
+								name,
+								message,
+								aliases,
+								choices,
+								tpsType,
+								type,
+								description,
+								hidden,
+								default: defaultValue,
+							} satisfies SettingsFilePrompt;
+						},
+					);
+
+					return {
+						...template,
+						settings: {
+							...template.settings,
+							prompts,
+						},
+					};
+				});
+
+			console.log(templatesSettingsSantitize);
+
+			const templatesSettingsMap = templatesSettingsSantitize.reduce(
+				(acc, templateSettings) => {
+					acc[templateSettings.name] = templateSettings;
+					return acc;
+				},
+				{},
+			);
+
+			setGlobalData({ templates: templatesSettingsMap });
+		},
+	};
+};

--- a/docs/plugins/templates-libraries-plugin.ts
+++ b/docs/plugins/templates-libraries-plugin.ts
@@ -48,8 +48,6 @@ const getTemplateSettings = async (
 		async (template) => {
 			const tps = new Templates(template);
 
-			// console.log(tps);
-
 			return {
 				name: tps.template,
 				settings: tps.templateSettings,

--- a/docs/plugins/templates-libraries-plugin.ts
+++ b/docs/plugins/templates-libraries-plugin.ts
@@ -15,8 +15,7 @@ export const TemplatesLibrariesPlugin = function TemplatesLibrariesPlugin(
 
 			const templatesSettings = await getTemplateSettings(templates);
 
-			// `setGlobalData` only allows passing in JSON compliant data since build is in a different enviroment
-			// well need to jsonify our data which involves getting rid functions and getting the value from `default`
+			// sanitize data so we can pass it to the frontend
 			const templatesSettingsSantitize: TemplateSettings[] =
 				sanitizeTemplateSettings(templatesSettings);
 

--- a/docs/plugins/templates-libraries-plugin.ts
+++ b/docs/plugins/templates-libraries-plugin.ts
@@ -1,7 +1,9 @@
+// ts-expect-error library is not available in tests
 import type {
 	SettingsFile,
 	SettingsFilePrompt,
 } from 'templates-mo/src/types/settings';
+// ts-expect-error library is not available in tests
 import Templates from 'templates-mo';
 
 interface TemplatesLibrariesPluginOptions {

--- a/docs/plugins/templates-libraries-plugin.ts
+++ b/docs/plugins/templates-libraries-plugin.ts
@@ -2,11 +2,15 @@ import type {
 	SettingsFile,
 	SettingsFilePrompt,
 } from 'templates-mo/src/types/settings';
+import Templates from 'templates-mo';
 
-const TEMPLATES_LIBRARIES: string[] = ['react-component', 'yargs-cli-cmd'];
+interface TemplatesLibrariesPluginOptions {
+	templates: string[];
+}
 
 export const TemplatesLibrariesPlugin = function TemplatesLibrariesPlugin(
-	templates: string[] = TEMPLATES_LIBRARIES,
+	context,
+	{ templates }: TemplatesLibrariesPluginOptions,
 ) {
 	return {
 		name: 'templates-libraries-plugin',
@@ -42,11 +46,13 @@ const getTemplateSettings = async (
 ): Promise<TemplateSettings[]> => {
 	const templatesSettingsPromises: Promise<TemplateSettings>[] = templates.map(
 		async (template) => {
+			const tps = new Templates(template);
+
+			console.log(tps);
+
 			return {
-				name: template,
-				settings: (await import(
-					`templates-mo/.tps/${template}/settings`
-				)) as SettingsFile,
+				name: tps.template,
+				settings: tps.templateSettings,
 			};
 		},
 	);

--- a/docs/plugins/templates-libraries-plugin.ts
+++ b/docs/plugins/templates-libraries-plugin.ts
@@ -48,7 +48,7 @@ const getTemplateSettings = async (
 		async (template) => {
 			const tps = new Templates(template);
 
-			console.log(tps);
+			// console.log(tps);
 
 			return {
 				name: tps.template,
@@ -70,7 +70,7 @@ function sanitizeTemplateSettings(
 	return templatesSettings.map((template) => {
 		const answers = {};
 
-		const prompts = template?.settings?.prompts.map((prompt) => {
+		const prompts = template?.settings?.prompts?.map((prompt) => {
 			const {
 				default: _default,
 				name,

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,5 +25,6 @@ module.exports = {
 	moduleNameMapper: {
 		'^@tps/(.+)$': path.join(__dirname, 'src/$1'),
 		'^@test/(.+)$': path.join(__dirname, '__tests__/$1'),
+		'^templates-mo$': path.join(__dirname),
 	},
 };

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -298,16 +298,10 @@ export class Templates<TAnswers extends AnswersHash = AnswersHash> {
 
 		try {
 			logger.tps.info('Loading template settings file...');
-
-			console.log('hey', settingsConfig.search(this.src));
-			fs.readFileSync(`${this.src}/settings.js`);
 			// eslint-disable-next-line
 			this.templateSettings = settingsConfig.search(this.src)?.config || {};
 		} catch (e) {
 			logger.tps.info(`Template has no Settings file`, e);
-
-			fs.readFileSync(`${this.src}/settings.js`);
-			console.log(e);
 			this.templateSettings = {} as SettingsFile;
 		}
 		logger.tps.info('Template settings: %n', this.templateSettings);

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -302,6 +302,7 @@ export class Templates<TAnswers extends AnswersHash = AnswersHash> {
 			this.templateSettings = settingsConfig.search(this.src)?.config || {};
 		} catch (e) {
 			logger.tps.info(`Template has no Settings file`, e);
+			console.log(e);
 			this.templateSettings = {} as SettingsFile;
 		}
 		logger.tps.info('Template settings: %n', this.templateSettings);

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -298,10 +298,15 @@ export class Templates<TAnswers extends AnswersHash = AnswersHash> {
 
 		try {
 			logger.tps.info('Loading template settings file...');
+
+			console.log('hey', settingsConfig.search(this.src));
+			fs.readFileSync(`${this.src}/settings.js`);
 			// eslint-disable-next-line
 			this.templateSettings = settingsConfig.search(this.src)?.config || {};
 		} catch (e) {
 			logger.tps.info(`Template has no Settings file`, e);
+
+			fs.readFileSync(`${this.src}/settings.js`);
 			console.log(e);
 			this.templateSettings = {} as SettingsFile;
 		}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -81,6 +81,6 @@ export type ValidateFn = (
 ) => (boolean | string) | Promise<boolean | string>;
 
 export interface SettingsFile {
-	opts: Partial<TemplateOptions>;
-	prompts: SettingsFilePrompt[];
+	opts?: Partial<TemplateOptions>;
+	prompts?: SettingsFilePrompt[];
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -6,7 +6,8 @@
 		"baseUrl": ".",
 		"paths": {
 			"@tps/*": ["./src/*"],
-			"@test/*": ["./__tests__/*"]
+			"@test/*": ["./__tests__/*"],
+			"templates-mo": ["./"]
 		}
 	},
 	"include": ["./src/**/*", "./__tests__/**/*"],

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -7,7 +7,7 @@
 		"paths": {
 			"@tps/*": ["./src/*"],
 			"@test/*": ["./__tests__/*"],
-			"templates-mo": ["./"]
+			"templates-mo/*": ["./*"]
 		}
 	},
 	"include": ["./src/**/*", "./__tests__/**/*"],

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -7,7 +7,8 @@
 		"paths": {
 			"@tps/*": ["./src/*"],
 			"@test/*": ["./__tests__/*"],
-			"templates-mo/*": ["./*"]
+			"templates-mo/*": ["./*"],
+			"templates-mo": ["./"]
 		}
 	},
 	"include": ["./src/**/*", "./__tests__/**/*"],


### PR DESCRIPTION
## Description

This PR changes the way we load a templates settings in the UI. 

Before, the UI would use `import` to fetch the settings file from the templates `.tps` folder. 

Now, we use a docusaurus plugin to pass down data during build time. The main reason for this change was to support the `events` initiative where we couldn't load certain modules in the UI (e.g zx). However, this fixes it for everyone who wants to use modules in prompter functions.

<img width="1049" alt="Screenshot 2024-08-23 at 6 07 57 PM" src="https://github.com/user-attachments/assets/ebce9477-4b0d-4b38-aa9e-4ceaea28be65">


