### PR TITLE
Typescript fixes

### DIFF
--- a/.bin/cli
+++ b/.bin/cli
@@ -2,4 +2,4 @@
 
 DIR="$( dirname "${BASH_SOURCE[0]}" )"
 
-npx ts-node --compiler ttypescript "$DIR/../src/cli" $@
+npx ts-node --compiler ts-patch/compiler "$DIR/../src/cli" $@

--- a/.bin/ts
+++ b/.bin/ts
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-npx ts-node --compiler ttypescript --project tsconfig.json $@
+npx ts-node --compiler ts-patch/compiler --project tsconfig.json $@

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "templates-mo",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "templates-mo",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "ISC",
 			"dependencies": {
 				"@types/yargs": "^17.0.24",
@@ -26,7 +26,6 @@
 				"prettyjson-256": "^1.6.5",
 				"strip-ansi": "6.0.0",
 				"ts-jest": "^29.0.5",
-				"typescript": "^4.9.4",
 				"yargs": "17.7.2"
 			},
 			"bin": {
@@ -42,11 +41,9 @@
 				"@types/node": "^20.14.10",
 				"@typescript-eslint/eslint-plugin": "^7.15.0",
 				"@typescript-eslint/parser": "^7.15.0",
-				"babel-eslint": "10.0.3",
 				"eslint": "^8.32.0",
 				"eslint-config-airbnb": "19.0.4",
 				"eslint-config-prettier": "^9.1.0",
-				"eslint-import-resolver-babel-module": "5.3.2",
 				"eslint-import-resolver-typescript": "^3.6.1",
 				"eslint-plugin-import": "^2.29.1",
 				"eslint-plugin-jest": "^28.6.0",
@@ -56,6 +53,7 @@
 				"jest": "29.0.0",
 				"prettier": "^3.3.2",
 				"ttypescript": "^1.5.15",
+				"typescript": "^5.5.4",
 				"typescript-transform-paths": "^3.4.6"
 			},
 			"engines": {
@@ -4413,27 +4411,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"node_modules/babel-eslint": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
-			"integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
-			"deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@babel/types": "^7.0.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"peerDependencies": {
-				"eslint": ">= 4.12.1"
-			}
-		},
 		"node_modules/babel-generator": {
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
@@ -4472,23 +4449,6 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dependencies": {
 				"babel-runtime": "^6.22.0"
-			}
-		},
-		"node_modules/babel-plugin-module-resolver": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-			"integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"find-babel-config": "^1.1.0",
-				"glob": "^7.1.2",
-				"pkg-up": "^2.0.0",
-				"reselect": "^3.0.1",
-				"resolve": "^1.4.0"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/babel-polyfill": {
@@ -6081,35 +6041,6 @@
 				"eslint": ">=7.0.0"
 			}
 		},
-		"node_modules/eslint-import-resolver-babel-module": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-babel-module/-/eslint-import-resolver-babel-module-5.3.2.tgz",
-			"integrity": "sha512-K7D8n0O6p/JJncPote8yiuB7chJfu26Yn/Q3gzT53cNzJNS0NUCkI0iuimj4/vWVRHVQvPnYWeq07V8RvKjz/A==",
-			"dev": true,
-			"dependencies": {
-				"pkg-up": "^3.1.0",
-				"resolve": "^1.20.0"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0",
-				"babel-plugin-module-resolver": "^3.0.0 || ^4.0.0 || ^5.0.0"
-			}
-		},
-		"node_modules/eslint-import-resolver-babel-module/node_modules/pkg-up": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-			"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/eslint-import-resolver-node": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -6772,15 +6703,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/eslint/node_modules/ansi-regex": {
@@ -7639,20 +7561,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/find-up": {
@@ -15886,82 +15794,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"find-up": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pkg-up/node_modules/find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"locate-path": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pkg-up/node_modules/locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pkg-up/node_modules/p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"p-try": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pkg-up/node_modules/p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"p-limit": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pkg-up/node_modules/p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -16848,13 +16680,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/reselect": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
@@ -18193,15 +18018,15 @@
 			"dev": true
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/typescript-transform-paths": {
@@ -22476,20 +22301,6 @@
 				}
 			}
 		},
-		"babel-eslint": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
-			"integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@babel/types": "^7.0.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			}
-		},
 		"babel-generator": {
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
@@ -22527,20 +22338,6 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
 				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-module-resolver": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-			"integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"find-babel-config": "^1.1.0",
-				"glob": "^7.1.2",
-				"pkg-up": "^2.0.0",
-				"reselect": "^3.0.1",
-				"resolve": "^1.4.0"
 			}
 		},
 		"babel-polyfill": {
@@ -23958,27 +23755,6 @@
 			"dev": true,
 			"requires": {}
 		},
-		"eslint-import-resolver-babel-module": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-babel-module/-/eslint-import-resolver-babel-module-5.3.2.tgz",
-			"integrity": "sha512-K7D8n0O6p/JJncPote8yiuB7chJfu26Yn/Q3gzT53cNzJNS0NUCkI0iuimj4/vWVRHVQvPnYWeq07V8RvKjz/A==",
-			"dev": true,
-			"requires": {
-				"pkg-up": "^3.1.0",
-				"resolve": "^1.20.0"
-			},
-			"dependencies": {
-				"pkg-up": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-					"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				}
-			}
-		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -24438,12 +24214,6 @@
 				}
 			}
 		},
-		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-			"dev": true
-		},
 		"espree": {
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -24894,17 +24664,6 @@
 				"randomatic": "^3.0.0",
 				"repeat-element": "^1.1.2",
 				"repeat-string": "^1.5.2"
-			}
-		},
-		"find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
 			}
 		},
 		"find-up": {
@@ -30845,66 +30604,6 @@
 				}
 			}
 		},
-		"pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"find-up": "^2.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true,
-					"peer": true
-				}
-			}
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -31595,13 +31294,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-		},
-		"reselect": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
-			"dev": true,
-			"peer": true
 		},
 		"resolve": {
 			"version": "1.22.8",
@@ -32585,9 +32277,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+			"version": "5.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
 		},
 		"typescript-transform-paths": {
 			"version": "3.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 				"eslint-plugin-react": "^7.34.3",
 				"jest": "29.0.0",
 				"prettier": "^3.3.2",
-				"ttypescript": "^1.5.15",
+				"ts-patch": "^3.2.1",
 				"typescript": "^5.5.4",
 				"typescript-transform-paths": "^3.4.6"
 			},
@@ -567,7 +567,7 @@
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
@@ -580,7 +580,7 @@
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -2841,28 +2841,28 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
 			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/@tsconfig/node16": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/@types/acorn": {
@@ -3894,7 +3894,7 @@
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -3973,7 +3973,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/argparse": {
@@ -5282,7 +5282,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/cross-spawn": {
@@ -5611,7 +5611,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=0.3.1"
@@ -15035,9 +15035,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -17799,7 +17799,7 @@
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
 			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
@@ -17837,6 +17837,127 @@
 				"@swc/wasm": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/ts-patch": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.2.1.tgz",
+			"integrity": "sha512-hlR43v+GUIUy8/ZGFP1DquEqPh7PFKQdDMTAmYt671kCCA6AkDQMoeFaFmZ7ObPLYOmpMgyKUqL1C+coFMf30w==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"global-prefix": "^3.0.0",
+				"minimist": "^1.2.8",
+				"resolve": "^1.22.2",
+				"semver": "^7.5.4",
+				"strip-ansi": "^6.0.1"
+			},
+			"bin": {
+				"ts-patch": "bin/ts-patch.js",
+				"tspc": "bin/tspc.js"
+			}
+		},
+		"node_modules/ts-patch/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ts-patch/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/ts-patch/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ts-patch/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/ts-patch/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/ts-patch/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ts-patch/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ts-patch/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ts-patch/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -17888,23 +18009,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
-		},
-		"node_modules/ttypescript": {
-			"version": "1.5.15",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
-			"integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
-			"dev": true,
-			"dependencies": {
-				"resolve": ">=1.9.0"
-			},
-			"bin": {
-				"ttsc": "bin/tsc",
-				"ttsserver": "bin/tsserver"
-			},
-			"peerDependencies": {
-				"ts-node": ">=8.0.2",
-				"typescript": ">=3.2.2"
-			}
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -18493,7 +18597,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/v8-to-istanbul": {
@@ -19099,7 +19203,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6"
@@ -19503,7 +19607,7 @@
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "0.3.9"
@@ -19513,7 +19617,7 @@
 					"version": "0.3.9",
 					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-					"devOptional": true,
+					"optional": true,
 					"peer": true,
 					"requires": {
 						"@jridgewell/resolve-uri": "^3.0.3",
@@ -21166,28 +21270,28 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
 			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"@tsconfig/node16": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"@types/acorn": {
@@ -21906,7 +22010,7 @@
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"ajv": {
@@ -21963,7 +22067,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"argparse": {
@@ -23000,7 +23104,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"cross-spawn": {
@@ -23249,7 +23353,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"diff-sequences": {
@@ -30033,9 +30137,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
 		},
 		"minipass": {
 			"version": "7.1.2",
@@ -32126,7 +32230,7 @@
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
 			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true,
 			"requires": {
 				"@cspotcode/source-map-support": "^0.8.0",
@@ -32142,6 +32246,92 @@
 				"make-error": "^1.1.1",
 				"v8-compile-cache-lib": "^3.0.1",
 				"yn": "3.1.1"
+			}
+		},
+		"ts-patch": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.2.1.tgz",
+			"integrity": "sha512-hlR43v+GUIUy8/ZGFP1DquEqPh7PFKQdDMTAmYt671kCCA6AkDQMoeFaFmZ7ObPLYOmpMgyKUqL1C+coFMf30w==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.2",
+				"global-prefix": "^3.0.0",
+				"minimist": "^1.2.8",
+				"resolve": "^1.22.2",
+				"semver": "^7.5.4",
+				"strip-ansi": "^6.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.6.3",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+					"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"tsconfig-paths": {
@@ -32187,15 +32377,6 @@
 					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.15",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
-			"integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-check": {
@@ -32629,7 +32810,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"v8-to-istanbul": {
@@ -33081,7 +33262,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"devOptional": true,
+			"optional": true,
 			"peer": true
 		},
 		"yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 		"jest": "29.0.0",
 		"prettier": "^3.3.2",
 		"ttypescript": "^1.5.15",
+		"typescript": "^5.5.4",
 		"typescript-transform-paths": "^3.4.6"
 	},
 	"dependencies": {
@@ -104,7 +105,6 @@
 		"prettyjson-256": "^1.6.5",
 		"strip-ansi": "6.0.0",
 		"ts-jest": "^29.0.5",
-		"typescript": "^4.9.4",
 		"yargs": "17.7.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"tps": "./lib/cli/index.js"
 	},
 	"scripts": {
-		"code:build": "ttsc",
+		"code:build": "tspc",
 		"code:dev": "npm run code:build -- -w",
 		"code:prod": "npm run code:build",
 		"test:run:init": "npm run test:jest -- --runInBand --testPathPattern cli/init",
@@ -83,7 +83,7 @@
 		"eslint-plugin-react": "^7.34.3",
 		"jest": "29.0.0",
 		"prettier": "^3.3.2",
-		"ttypescript": "^1.5.15",
+		"ts-patch": "^3.2.1",
 		"typescript": "^5.5.4",
 		"typescript-transform-paths": "^3.4.6"
 	},


### PR DESCRIPTION
## Description

This PR addresses issues in the #210 where settings file isnt able to use a dynamic import which may stem from ttypescript. along with this we will upgrade typescript while we are at it

- upgrade typescript to 5.5.4
- Remove ttypescript (deprecated) in favor for [ts-patch](https://www.npmjs.com/package/ts-patch)