### PR TITLE
Add prettier support to yargs-cli-cmd template

### DIFF
--- a/.tps/express-app/settings.js
+++ b/.tps/express-app/settings.js
@@ -33,14 +33,14 @@ module.exports = {
 		},
 	],
 	events: {
-		onRendered(tps, { buildPaths }) {
+		onRendered(tps, { dest, buildPaths }) {
 			const answers = tps.getAnswers();
 
 			const pm = packageManagers[answers.packageManager];
 
 			buildPaths.forEach((path) => {
 				// TODO: if someone runs with multiple build paths it will display two "Running npm install"
-				runCommand(pm, [path]);
+				runCommand(pm, dest, [path], tps);
 			});
 		},
 	},

--- a/.tps/react-component/settings.js
+++ b/.tps/react-component/settings.js
@@ -216,12 +216,12 @@ module.exports = {
 
 			const answers = tps.getAnswers();
 
-			runFormatter(answers.formatter, directoryForPrettier);
+			runFormatter(answers.formatter, dest, directoryForPrettier, tps);
 
 			const linter = linters[answers.linter] ?? null;
 
 			if (linter) {
-				runCommand(linter, directoryForPrettier);
+				runCommand(linter, dest, directoryForPrettier);
 			}
 		},
 	},

--- a/.tps/react-component/settings.js
+++ b/.tps/react-component/settings.js
@@ -1,6 +1,11 @@
 // @ts-check
 
-const { formatters, linters, runCommand } = require('../../lib/tools');
+const {
+	runFormatter,
+	linters,
+	runCommand,
+	FORMATTER_PROMPT,
+} = require('../../lib/tools');
 
 /** @type {import('../../src/types/settings').SettingsFile} */
 module.exports = {
@@ -191,18 +196,7 @@ module.exports = {
 			tpsType: 'package',
 			default: false,
 		},
-		{
-			name: 'formatter',
-			aliases: ['format'],
-			description:
-				'Type of formatter you would like to use to format the component',
-			message: 'What type of formatter do you want to use to format your code',
-			type: 'list',
-			tpsType: 'data',
-			hidden: true,
-			choices: ['none', 'prettier', 'biome'],
-			default: 'none',
-		},
+		FORMATTER_PROMPT,
 		{
 			name: 'linter',
 			aliases: ['lint'],
@@ -222,11 +216,7 @@ module.exports = {
 
 			const answers = tps.getAnswers();
 
-			const formatter = formatters[answers.formatter] ?? null;
-
-			if (formatter) {
-				runCommand(formatter, directoryForPrettier);
-			}
+			runFormatter(answers.formatter, directoryForPrettier);
 
 			const linter = linters[answers.linter] ?? null;
 

--- a/.tps/yargs-cli-cmd/settings.js
+++ b/.tps/yargs-cli-cmd/settings.js
@@ -1,4 +1,5 @@
 // @ts-check
+const { runFormatter, FORMATTER_PROMPT } = require('../../lib/tools');
 
 /** @type {import('./../../src/types/settings').SettingsFile} */
 module.exports = {
@@ -50,5 +51,15 @@ module.exports = {
 			message: 'Please add a description',
 			default: '...',
 		},
+		FORMATTER_PROMPT,
 	],
+	events: {
+		async onRendered(tps, { dest, buildPaths }) {
+			const directoryForPrettier = tps.opts.newFolder ? buildPaths : [dest];
+
+			const answers = tps.getAnswers();
+
+			runFormatter(answers.formatter, dest, directoryForPrettier, tps);
+		},
+	},
 };

--- a/__tests__/tests/default-templates/express-app.jest.ts
+++ b/__tests__/tests/default-templates/express-app.jest.ts
@@ -156,11 +156,11 @@ app.use('/', router);
 			// @ts-expect-error no types for extending jest functions
 			expect(path.join(CWD, 'app')).toBeDirectory();
 
-			expect(sync).toBeCalledWith('npm', [
-				'install',
-				'--prefix',
-				path.join(CWD, 'app'),
-			]);
+			expect(sync).toBeCalledWith(
+				'npm',
+				['install', '--prefix', path.join(CWD, 'app')],
+				expect.objectContaining({}),
+			);
 		});
 
 		it('should be able to render the express app template with yarn', async () => {
@@ -175,11 +175,11 @@ app.use('/', router);
 			// @ts-expect-error no types for extending jest functions
 			expect(path.join(CWD, 'app')).toBeDirectory();
 
-			expect(sync).toBeCalledWith('yarn', [
-				'install',
-				'--cwd',
-				path.join(CWD, 'app'),
-			]);
+			expect(sync).toBeCalledWith(
+				'yarn',
+				['install', '--cwd', path.join(CWD, 'app')],
+				expect.objectContaining({}),
+			);
 		});
 	});
 });

--- a/__tests__/tests/templates/tools.jest.ts
+++ b/__tests__/tests/templates/tools.jest.ts
@@ -1,0 +1,244 @@
+/*
+ * Modules
+ */
+import { mkTemplate } from '@test/utilities/templates';
+import { CWD, MAIN_DIR } from '@tps/utilities/constants';
+import Templates from '@tps/templates';
+import { OutputProcessor, runCommand, runFormatter } from '@tps/tools';
+import { reset, vol } from '@test/utilities/vol';
+import path from 'path';
+import { sync } from 'cross-spawn';
+import {
+	mkCrossSpawn,
+	mkErrnoException,
+	mockConsoleLog,
+} from '@test/utilities/mocks';
+
+jest.mock('cross-spawn');
+
+jest.mock('fs');
+
+const DEFAULT_COMMAND: OutputProcessor = {
+	args: () => ['--some-flag'],
+	command: 'command',
+	name: 'Command1',
+};
+
+describe('Tools:', () => {
+	beforeEach(() => {
+		mockConsoleLog();
+
+		jest.resetAllMocks();
+		reset();
+	});
+
+	describe('runCommand', () => {
+		it('should be able to run a command', async () => {
+			const templateName = 'run-comand';
+
+			mkTemplate(templateName);
+
+			const tps = new Templates(templateName, {
+				default: true,
+			});
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')], tps);
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({}),
+			);
+		});
+
+		it.each([
+			{ type: 'templates main directory', dir: MAIN_DIR },
+			{ type: 'instance dest', dir: CWD },
+		])('should include $type .bin in PATH', async ({ dir }) => {
+			const templateName = 'run-comand';
+
+			mkTemplate(templateName);
+
+			const tps = new Templates(templateName, {
+				default: true,
+			});
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')], tps);
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({
+					env: expect.objectContaining({
+						PATH: expect.stringContaining(path.join(dir, 'node_modules/.bin')),
+					}),
+				}),
+			);
+		});
+
+		it('should include template directory in PATH', async () => {
+			const templateName = 'run-comand';
+
+			mkTemplate(templateName);
+
+			const tps = new Templates(templateName, {
+				default: true,
+			});
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')], tps);
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({
+					env: expect.objectContaining({
+						PATH: expect.stringContaining(
+							path.join(tps.src, 'node_modules/.bin'),
+						),
+					}),
+				}),
+			);
+		});
+
+		it('should include all bins from $PATH', async () => {
+			const templateName = 'run-comand';
+
+			mkTemplate(templateName);
+
+			const tps = new Templates(templateName, {
+				default: true,
+			});
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')], tps);
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({
+					env: expect.objectContaining({
+						PATH: expect.stringContaining(process.env.PATH),
+					}),
+				}),
+			);
+		});
+
+		it('Should be able to handle errors', async () => {
+			const log = mockConsoleLog();
+
+			jest.mocked(sync).mockReturnValue(
+				mkCrossSpawn({
+					error: mkErrnoException(
+						'Permission denied',
+						'EACCES',
+						'open',
+						'/path/to/file',
+					),
+				}),
+			);
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')]);
+
+			expect(log.get()).toContain('❌ Command1 failed');
+
+			expect(log.get()).toContain('Error: Permission denied');
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({
+					env: expect.objectContaining({
+						PATH: expect.stringContaining(process.env.PATH),
+					}),
+				}),
+			);
+		});
+
+		it('Should give better error message when command is not found', async () => {
+			const log = mockConsoleLog();
+
+			jest.mocked(sync).mockReturnValue(
+				mkCrossSpawn({
+					error: mkErrnoException('Command not found', 'ENOENT'),
+				}),
+			);
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')]);
+
+			expect(log.get()).toContain('❌ Command not found: command');
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({
+					env: expect.objectContaining({
+						PATH: expect.stringContaining(process.env.PATH),
+					}),
+				}),
+			);
+		});
+
+		it('Should be able to error status code', async () => {
+			const log = mockConsoleLog();
+
+			jest.mocked(sync).mockReturnValue(
+				mkCrossSpawn({
+					status: 1,
+					stdout: 'some stdout',
+					stderr: 'some stderr',
+				}),
+			);
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')]);
+
+			expect(log.get()).toContain('❌ Command1 failed');
+
+			expect(log.get()).toContain('some stdout');
+			expect(log.get()).toContain('some stderr');
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({
+					env: expect.objectContaining({
+						PATH: expect.stringContaining(process.env.PATH),
+					}),
+				}),
+			);
+		});
+	});
+
+	describe('runFormatter', () => {
+		it('should handle none', async () => {
+			await expect(runFormatter('none', '', [])).resolves.toBeUndefined();
+
+			expect(sync).not.toBeCalled();
+		});
+
+		it('should handle when formatter doesnt exist', async () => {
+			// @ts-expect-error need to test when known value
+			await expect(runFormatter('unknown', '', [])).resolves.toBeUndefined();
+
+			expect(sync).not.toBeCalled();
+		});
+
+		it('should run correct formatter', async () => {
+			await expect(
+				runFormatter('prettier', '/some/path', ['buildPath']),
+			).resolves.toBeUndefined();
+
+			expect(sync).toHaveBeenCalledWith(
+				'prettier',
+				[
+					'--ignore-unknown',
+					'buildPath',
+					'--write',
+					'--ignore-path',
+					'./.prettierignore',
+				],
+				expect.objectContaining({}),
+			);
+		});
+	});
+
+	// it('should ...', async () => {});
+});

--- a/__tests__/tests/templates/tools.jest.ts
+++ b/__tests__/tests/templates/tools.jest.ts
@@ -26,7 +26,7 @@ const DEFAULT_COMMAND: OutputProcessor = {
 
 describe('Tools:', () => {
 	beforeEach(() => {
-		// mockConsoleLog();
+		mockConsoleLog();
 
 		jest.resetAllMocks();
 		reset();
@@ -51,10 +51,7 @@ describe('Tools:', () => {
 			);
 		});
 
-		it.each([
-			{ type: 'templates main directory', dir: MAIN_DIR },
-			{ type: 'instance dest', dir: CWD },
-		])('should include $type .bin in PATH', async ({ dir }) => {
+		it('should include templates main directory .bin in PATH', async () => {
 			const templateName = 'run-comand';
 
 			mkTemplate(templateName);
@@ -70,7 +67,35 @@ describe('Tools:', () => {
 				['--some-flag'],
 				expect.objectContaining({
 					env: expect.objectContaining({
-						PATH: expect.stringContaining(path.join(dir, 'node_modules/.bin')),
+						PATH: expect.stringContaining(
+							path.join(MAIN_DIR, 'node_modules/.bin'),
+						),
+					}),
+				}),
+			);
+		});
+
+		it('should include dest .bin in PATH', async () => {
+			const templateName = 'run-comand';
+
+			mkTemplate(templateName);
+
+			await vol.promises.mkdir(path.join(CWD, 'node_modules'), {
+				recursive: true,
+			});
+
+			const tps = new Templates(templateName, {
+				default: true,
+			});
+
+			runCommand(DEFAULT_COMMAND, CWD, [path.join(CWD, 'app')], tps);
+
+			expect(sync).toHaveBeenCalledWith(
+				'command',
+				['--some-flag'],
+				expect.objectContaining({
+					env: expect.objectContaining({
+						PATH: expect.stringContaining(path.join(CWD, 'node_modules/.bin')),
 					}),
 				}),
 			);

--- a/__tests__/tests/templates/tools.jest.ts
+++ b/__tests__/tests/templates/tools.jest.ts
@@ -227,6 +227,4 @@ describe('Tools:', () => {
 			);
 		});
 	});
-
-	// it('should ...', async () => {});
 });

--- a/__tests__/tests/templates/tools.jest.ts
+++ b/__tests__/tests/templates/tools.jest.ts
@@ -145,11 +145,7 @@ describe('Tools:', () => {
 			expect(sync).toHaveBeenCalledWith(
 				'command',
 				['--some-flag'],
-				expect.objectContaining({
-					env: expect.objectContaining({
-						PATH: expect.stringContaining(process.env.PATH),
-					}),
-				}),
+				expect.objectContaining({}),
 			);
 		});
 
@@ -169,11 +165,7 @@ describe('Tools:', () => {
 			expect(sync).toHaveBeenCalledWith(
 				'command',
 				['--some-flag'],
-				expect.objectContaining({
-					env: expect.objectContaining({
-						PATH: expect.stringContaining(process.env.PATH),
-					}),
-				}),
+				expect.objectContaining({}),
 			);
 		});
 
@@ -198,11 +190,7 @@ describe('Tools:', () => {
 			expect(sync).toHaveBeenCalledWith(
 				'command',
 				['--some-flag'],
-				expect.objectContaining({
-					env: expect.objectContaining({
-						PATH: expect.stringContaining(process.env.PATH),
-					}),
-				}),
+				expect.objectContaining({}),
 			);
 		});
 	});

--- a/__tests__/tests/templates/tools.jest.ts
+++ b/__tests__/tests/templates/tools.jest.ts
@@ -5,7 +5,7 @@ import { mkTemplate } from '@test/utilities/templates';
 import { CWD, MAIN_DIR } from '@tps/utilities/constants';
 import Templates from '@tps/templates';
 import { OutputProcessor, runCommand, runFormatter } from '@tps/tools';
-import { reset, vol } from '@test/utilities/vol';
+import { reset } from '@test/utilities/vol';
 import path from 'path';
 import { sync } from 'cross-spawn';
 import {

--- a/__tests__/utilities/mocks.ts
+++ b/__tests__/utilities/mocks.ts
@@ -1,3 +1,6 @@
+import { sync } from 'cross-spawn';
+import type { ExecFileException, SpawnSyncReturns } from 'child_process';
+
 export interface MockedConsole {
 	original: typeof console.log;
 	log: jest.SpyInstance;
@@ -30,3 +33,48 @@ export const mockConsoleLog = (): MockedConsole => {
 		},
 	};
 };
+
+interface CrossSpawnReturn<T = Buffer> extends SpawnSyncReturns<T> {
+	error?: ExecFileException;
+}
+
+const DEFAULT_CROSS_SPAWN: CrossSpawnReturn = {
+	pid: 123,
+	output: [Buffer.from('hey')],
+	signal: null,
+	status: 0,
+	stdout: Buffer.from('test output'),
+	stderr: Buffer.from(''),
+};
+
+export const mkCrossSpawn = (
+	spawn: Partial<CrossSpawnReturn<string>>,
+): CrossSpawnReturn => {
+	return {
+		...DEFAULT_CROSS_SPAWN,
+		...spawn,
+		output: (spawn?.output || DEFAULT_CROSS_SPAWN.output).map((s) =>
+			Buffer.from(s),
+		),
+		stdout: Buffer.from(spawn?.stdout || DEFAULT_CROSS_SPAWN.stdout),
+		stderr: Buffer.from(spawn?.stderr || DEFAULT_CROSS_SPAWN.stderr),
+	};
+};
+
+export function mkErrnoException(
+	message: string,
+	code: string,
+	syscall?: string,
+	path?: string,
+): NodeJS.ErrnoException {
+	const error = new Error(message) as NodeJS.ErrnoException;
+	error.code = code;
+	error.errno = 1; // idk
+	if (syscall) {
+		error.syscall = syscall;
+	}
+	if (path) {
+		error.path = path;
+	}
+	return error;
+}

--- a/__tests__/utilities/mocks.ts
+++ b/__tests__/utilities/mocks.ts
@@ -1,4 +1,3 @@
-import { sync } from 'cross-spawn';
 import type { ExecFileException, SpawnSyncReturns } from 'child_process';
 
 export interface MockedConsole {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "templates-mo",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Templates is a powerful filesystem generator that aims to simplify the process of getting started with and maintaining code applications",
 	"main": "lib/templates/index.js",
 	"keywords": [

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -123,7 +123,6 @@ export const runCommand = (
 		? [path.resolve(tps.src, 'node_modules', '.bin')]
 		: [];
 
-	console.log('hey', destNodeModulesBin);
 	const bins = [
 		// Bins from main template directory which satisfies default templates
 		templatesNodeModulesBin,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -64,13 +64,14 @@ const formattersMap: OutputProcessorMap<formatters> = {
 
 export const runFormatter = async (
 	formatter: formatters,
+	cwd: string,
 	paths: string[],
 	tps: Templates,
 ): Promise<void> => {
 	const formatterObj = formattersMap[formatter] ?? null;
 
 	if (formatter) {
-		runCommand(formatterObj, paths, tps);
+		runCommand(formatterObj, cwd, paths, tps);
 	}
 };
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import { sync } from 'cross-spawn';
 import type { SettingsFilePrompt } from '@tps/types/settings';
 import path from 'path';
 import Templates from '@tps/templates';
+import { findUp } from '@tps/utilities/fileSystem';
 
 const NONE = 'none';
 
@@ -112,17 +113,22 @@ export const runCommand = (
 	);
 
 	// TODO: Use find up
-	const destNodeModulesBin = path.resolve(cwd, 'node_modules', '.bin');
+	// const destNodeModulesBin = path.resolve(cwd, 'node_modules', '.bin');
+	const parentNodeModules = findUp('node_modules', cwd);
+	const destNodeModulesBin = parentNodeModules
+		? [path.resolve(parentNodeModules, '.bin')]
+		: [];
 
 	const templateNodeModuleBin = tps
 		? [path.resolve(tps.src, 'node_modules', '.bin')]
 		: [];
 
+	console.log('hey', destNodeModulesBin);
 	const bins = [
 		// Bins from main template directory which satisfies default templates
 		templatesNodeModulesBin,
 		// Bins from Modules from the `cwd` or in other words `dest`
-		destNodeModulesBin,
+		...destNodeModulesBin,
 		// Bins from template modules
 		...templateNodeModuleBin,
 		process.env.PATH,


### PR DESCRIPTION
## Description

This PR refactors the formatter logic from `react-component` so `yargs-cli-cmd` can use it

This PR also enhances our function that runs our commands:
- better support when command is not found
- handles errors
- add tests
