### PR TITLE
Express-app: Remove typescript and mongo from beta docs

### DIFF
--- a/docs/docs/main/templates/express-app.mdx
+++ b/docs/docs/main/templates/express-app.mdx
@@ -32,10 +32,9 @@ This template is in its alpha stage and will be evolving rapidly with new
 features and updates. Changes may include directory structures, Express app
 patterns, and more. We are also planning to support:
 
--   TypeScript
 -   React
 -   Modes (production, playground, etc.)
--   Databases (Mongo, SQL, etc.)
+-   Databases (SQL, etc.)
 -   And
     [more...](https://github.com/users/marcellino-ornelas/projects/2/views/5?pane=issue&itemId=59501342)
 


### PR DESCRIPTION
## Description

Typescript and mongo is already supported
