### PR TITLE
Fix list command not displaying templates in prod

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -141,7 +141,7 @@ export default {
 					return [];
 				}
 
-				if (templateDir.includes('node_modules')) {
+				if (path.parse(templateDir).base === 'node_modules') {
 					/**
 					 * Only print out packages that start with `tps`
 					 */


### PR DESCRIPTION
## Description

Fix the list command not displaying default templates. 

The issue was that when in prod, the main template directory was in the node modules directory which was only filtering termplates that started with `tps` thus getting rid of all of the default templates