### PR TITLE
Support loading template settings with and without tps- prefix

### DIFF
--- a/__tests__/tests/templates/tpsrc_v2.jest.ts
+++ b/__tests__/tests/templates/tpsrc_v2.jest.ts
@@ -14,6 +14,7 @@ import {
 	mkPrompt,
 	mkTpsrc,
 	mk3rdPartyTemplate,
+	mkTemplate,
 } from '@test/utilities/templates';
 
 jest.mock('fs');
@@ -283,6 +284,48 @@ testing-prompt-core:
 
 		// eslint-disable-next-line no-underscore-dangle
 		expect(tps._prompts.answers.prompt1).toBeTruthy();
+	});
+
+	it('should be able to load settings for template that uses tps-prefix', () => {
+		mkTpsrc(path.join(CWD, '.tps/.tpsrc'), {
+			'tps-app': {
+				opts: {
+					extendedDest: './app',
+				},
+			},
+		});
+
+		const tps = mkTemplate('tps-app');
+
+		expect(tps.opts.extendedDest).toBe('./app');
+	});
+
+	it('should be able to load settings for template when user doesnt use tps- prefix in tpsrc but template has tps- prefeix', () => {
+		mkTpsrc(path.join(CWD, '.tps/.tpsrc'), {
+			app: {
+				opts: {
+					extendedDest: './app',
+				},
+			},
+		});
+
+		const tps = mkTemplate('tps-app');
+
+		expect(tps.opts.extendedDest).toBe('./app');
+	});
+
+	it('should be able to load settings for template when user doesnt use tps- prefix in tpsrc but template has tps- prefeix', () => {
+		mkTpsrc(path.join(CWD, '.tps/.tpsrc'), {
+			'tps-app': {
+				opts: {
+					extendedDest: './app',
+				},
+			},
+		});
+
+		const tps = mkTemplate('app');
+
+		expect(tps.opts.extendedDest).toBe('./app');
 	});
 
 	// it('should be able to override a tpsrc file location', () => {

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -24,6 +24,7 @@ import {
 	hasProp,
 	getNpmPaths,
 	getAllDirectoriesAndUp,
+	stripPrefix,
 } from '@tps/utilities/helpers';
 import {
 	TemplateNotFoundError,
@@ -1050,7 +1051,11 @@ export class Templates<TAnswers extends AnswersHash = AnswersHash> {
 	}
 
 	private _loadTpsSpecificConfig(templateName: string, config: Tpsrc): void {
-		const templateConfig = config[templateName] ?? null;
+		const templateConfig =
+			config[templateName] ??
+			config[`tps-${templateName}`] ??
+			config[stripPrefix(templateName, 'tps-')] ??
+			null;
 
 		if (templateConfig && is.object(templateConfig)) {
 			logger.tps.info('Loading configuration: %n', templateConfig);

--- a/src/utilities/helpers.ts
+++ b/src/utilities/helpers.ts
@@ -149,6 +149,12 @@ export const unique = <T extends string | number>(array: T[]): T[] => {
 	return uniqueArray;
 };
 
+/**
+ * strip the prefix from the provided string
+ *
+ * @example
+ * 		stripPrefix("tps-app", "tps-"); // "app"
+ */
 export const stripPrefix = (str: string, prefix: string): string => {
 	if (str.startsWith(prefix)) {
 		return str.slice(prefix.length);

--- a/src/utilities/helpers.ts
+++ b/src/utilities/helpers.ts
@@ -148,3 +148,10 @@ export const unique = <T extends string | number>(array: T[]): T[] => {
 
 	return uniqueArray;
 };
+
+export const stripPrefix = (str: string, prefix: string): string => {
+	if (str.startsWith(prefix)) {
+		return str.slice(prefix.length);
+	}
+	return str;
+};


### PR DESCRIPTION
## Description

Support loading template settings when the template name in `.tpsrc` has or doesn't have the `tps-` prefix. This is mainly to support 3rd party libraries. We recommend adding a `tps-` prefix due to discoverability issues. However currently tpsrc requires you to add `tps-` prefix in order to load settings. The nice thing about `tps-` is that its removable so we should support this in tpsrc for easier template naming and constancy

**Example**
For template `tps-some-template`, users should be able to define options or answers in `.tpsrc` under `tps-some-template` and `some-template`