### PR TITLE
Core: Fail templates when event throws error

### DIFF
--- a/__tests__/tests/templates/settings.jest.js
+++ b/__tests__/tests/templates/settings.jest.js
@@ -77,9 +77,11 @@ describe('[Templates] Settings:', () => {
 			tps.templateSettings.events.onRendered = jest
 				.fn()
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				.mockImplementation((_, createdPath) => {
+				.mockImplementation((_, { buildPaths }) => {
 					// all build paths should be completed
-					expect(createdPath).toBeDirectory();
+					buildPaths.forEach((createdPath) => {
+						expect(createdPath).toBeDirectory();
+					});
 				});
 
 			await tps.render(CWD, 'App');
@@ -99,9 +101,9 @@ describe('[Templates] Settings:', () => {
 			tps.templateSettings.events.onRendered = jest
 				.fn()
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				.mockImplementation((_, createdPaths) => {
+				.mockImplementation((_, { buildPaths }) => {
 					// all build paths should be completed
-					createdPaths.forEach((createdPath) => {
+					buildPaths.forEach((createdPath) => {
 						expect(createdPath).toBeDirectory();
 					});
 				});
@@ -123,7 +125,7 @@ describe('[Templates] Settings:', () => {
 			tps.templateSettings.events.onBuildPathRender = jest
 				.fn()
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				.mockImplementation((_, buildPath) => {
+				.mockImplementation((_, { buildPath }) => {
 					expect(buildPath).not.toBeDirectory();
 				});
 
@@ -155,7 +157,7 @@ describe('[Templates] Settings:', () => {
 			tps.templateSettings.events.onBuildPathRendered = jest
 				.fn()
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				.mockImplementation((_, buildPath) => {
+				.mockImplementation((_, { buildPath }) => {
 					expect(buildPath).toBeDirectory();
 				});
 

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -508,6 +508,7 @@ export class Templates<TAnswers extends AnswersHash = AnswersHash> {
 
 		await Promise.all(builders);
 
+		// TODO: When a event fails should we clean up the build path?
 		await this._emitEvent('onRendered', {
 			dest: finalDest,
 			buildPaths: pathsToCreate,
@@ -1085,12 +1086,8 @@ export class Templates<TAnswers extends AnswersHash = AnswersHash> {
 		const events = this.templateSettings?.events ?? null;
 		if (events && event in events && typeof events[event] === 'function') {
 			logger.tps.info(`Running ${event} function...`);
-			try {
-				// @ts-expect-error idk lol
-				await events[event]?.(this, ...args);
-			} catch (e) {
-				logger.tps.error(`Event ${event} failed: %n`, e);
-			}
+			// @ts-expect-error idk lol
+			await events[event]?.(this, ...args);
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fail templates when event throws error. 

Not only will this make events easier to debug. This also will allow templates to make their own choice on whether or not they want to stop process the command. If a template doesn't want to fail a event, then they can wrap their specific logic in a try catch. Currenly templates that want to fail the command, don't have any way to fail the template command if they wanted to.

### Future

- Should we run our cleanup logic after a event throws a error?