### PR TITLE
support .tpskeep files

### DIFF
--- a/__tests__/tests/fileSystemTree/DirectoryNode.jest.ts
+++ b/__tests__/tests/fileSystemTree/DirectoryNode.jest.ts
@@ -57,7 +57,7 @@ describe('[FileSystemTree] DirectoryNode:', () => {
 
 	it('should exclude files that match ignore files', () => {
 		const filename = 'extras2.js';
-		FileSystemNode.ignoreFiles = `**/${filename}.js`;
+		FileSystemNode.ignoreFiles = [`**/${filename}.js`];
 		mainDir = new DirNode('main', PATH_TO_TEMPLATES);
 		const files = mainDir.find({ name: filename });
 		expect(files).toHaveLength(0);

--- a/__tests__/tests/fileSystemTree/DirectoryNode.jest.ts
+++ b/__tests__/tests/fileSystemTree/DirectoryNode.jest.ts
@@ -5,8 +5,12 @@ import * as path from 'path';
 import fs from 'fs';
 import { DirNode, FileSystemNode } from '@tps/fileSystemTree';
 import { TESTING_TPS } from '@test/utilities/constants';
+import { reset, vol } from '@test/utilities/vol';
 
 jest.mock('fs');
+
+const PATH = '/temp/random';
+const MAIN_PATH = path.join(PATH, 'main');
 
 /*
  * Constants
@@ -17,7 +21,14 @@ const PATH_TO_MAIN_DIRECORY = path.join(PATH_TO_TEMPLATES, 'main');
 describe('[FileSystemTree] DirectoryNode:', () => {
 	let mainDir: DirNode;
 
-	beforeAll(() => {
+	beforeEach(() => {
+		reset();
+		FileSystemNode.ignoreFiles = [];
+		vol.toJSON(PATH, {
+			'./main/index.js': 'index',
+			'./main/.tpskeep': '',
+			'./main/.gitkeep': '',
+		});
 		mainDir = new DirNode('main', PATH_TO_TEMPLATES);
 	});
 
@@ -57,7 +68,7 @@ describe('[FileSystemTree] DirectoryNode:', () => {
 
 	it('should exclude files that match ignore files', () => {
 		const filename = 'extras2.js';
-		FileSystemNode.ignoreFiles = `**/${filename}.js`;
+		FileSystemNode.ignoreFiles = [`**/${filename}.js`];
 		mainDir = new DirNode('main', PATH_TO_TEMPLATES);
 		const files = mainDir.find({ name: filename });
 		expect(files).toHaveLength(0);

--- a/__tests__/tests/fileSystemTree/DirectoryNode.jest.ts
+++ b/__tests__/tests/fileSystemTree/DirectoryNode.jest.ts
@@ -5,12 +5,8 @@ import * as path from 'path';
 import fs from 'fs';
 import { DirNode, FileSystemNode } from '@tps/fileSystemTree';
 import { TESTING_TPS } from '@test/utilities/constants';
-import { reset, vol } from '@test/utilities/vol';
 
 jest.mock('fs');
-
-const PATH = '/temp/random';
-const MAIN_PATH = path.join(PATH, 'main');
 
 /*
  * Constants
@@ -21,14 +17,7 @@ const PATH_TO_MAIN_DIRECORY = path.join(PATH_TO_TEMPLATES, 'main');
 describe('[FileSystemTree] DirectoryNode:', () => {
 	let mainDir: DirNode;
 
-	beforeEach(() => {
-		reset();
-		FileSystemNode.ignoreFiles = [];
-		vol.toJSON(PATH, {
-			'./main/index.js': 'index',
-			'./main/.tpskeep': '',
-			'./main/.gitkeep': '',
-		});
+	beforeAll(() => {
 		mainDir = new DirNode('main', PATH_TO_TEMPLATES);
 	});
 
@@ -68,7 +57,7 @@ describe('[FileSystemTree] DirectoryNode:', () => {
 
 	it('should exclude files that match ignore files', () => {
 		const filename = 'extras2.js';
-		FileSystemNode.ignoreFiles = [`**/${filename}.js`];
+		FileSystemNode.ignoreFiles = `**/${filename}.js`;
 		mainDir = new DirNode('main', PATH_TO_TEMPLATES);
 		const files = mainDir.find({ name: filename });
 		expect(files).toHaveLength(0);

--- a/__tests__/tests/templates/rendering/core.jest.js
+++ b/__tests__/tests/templates/rendering/core.jest.js
@@ -337,4 +337,29 @@ describe('[Templates] Render Process:', () => {
 			expect(destPath).toHaveAllFilesAndDirectories(['index.js']);
 		});
 	});
+
+	// TODO: remove .gitkeep
+	it('should ignore .tpskeep & .gitkeep files', () => {
+		const tps = mkTemplate('my-template', undefined, {
+			'./default/some-directory/.tpskeep': '',
+			'./default/some-directory-nested/nested/.tpskeep': '',
+			'./default/some-directory/.gitkeep': '',
+			'./default/some-directory-nested/nested/.gitkeep': '',
+			'./default/index.js': '',
+		});
+
+		return tps.render(playground.box(), 'app').then(() => {
+			expect(
+				playground.pathTo('app/some-directory'),
+			).not.toHaveAllFilesAndDirectories(['.tpskeep', '.gitkeep']);
+
+			expect(
+				playground.pathTo('app/some-directory-nested/nested'),
+			).not.toHaveAllFilesAndDirectories(['.tpskeep', '.gitkeep']);
+
+			expect(playground.pathTo('app/')).toHaveAllFilesAndDirectories([
+				'index.js',
+			]);
+		});
+	});
 });

--- a/src/fileSystemTree/directoryNode.ts
+++ b/src/fileSystemTree/directoryNode.ts
@@ -47,7 +47,13 @@ export class DirectoryNode extends FileSystemNode {
 		}
 
 		directoryChildren
-			.filter((child) => !minimatch(child, FileSystemNode.ignoreFiles))
+			// TODO: should probably be done in the templates file instead
+			// Filter out files that match the ignoreFiles pattern
+			.filter((child) => {
+				return !FileSystemNode.ignoreFiles.some((ignoreFile) =>
+					minimatch(child, ignoreFile),
+				);
+			})
 			.forEach((name) => {
 				const dirContentPath = path.join(this.path, name);
 				const ContentType = isDir(dirContentPath) ? DirectoryNode : FileNode;

--- a/src/fileSystemTree/fileSystemNode.ts
+++ b/src/fileSystemTree/fileSystemNode.ts
@@ -17,7 +17,7 @@ export interface FileSystemNodeCallback<TReturn = void>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export abstract class FileSystemNode extends Tree<null, FileSystemNode> {
-	static ignoreFiles = '';
+	static ignoreFiles: string[] = [];
 
 	public depth: number;
 

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -72,7 +72,7 @@ if (TPS.IS_TESTING) {
 	logger.tps.opts.disableLog = true;
 }
 
-FileSystemNode.ignoreFiles = '**/.gitkeep';
+FileSystemNode.ignoreFiles = ['**/.gitkeep', '**/.tpskeep'];
 
 const settingsConfig = cosmiconfigSync(TPS.TEMPLATE_SETTINGS_FILE, {
 	cache: !TPS.IS_TESTING,


### PR DESCRIPTION
## Description

Support `.tpskeep` files so empty directories can be upload to github but without showing up in a templates instance.

Currently `.gitkeep` file is support for this exact reason but if template owners want to use this file then the will not be able to so by suppoting a tpskeep file we will no longer need git keep