### PR TITLE
Use default value for all unanswered answers

### DIFF
--- a/__tests__/tests/prompter/core.jest.ts
+++ b/__tests__/tests/prompter/core.jest.ts
@@ -260,4 +260,30 @@ describe('[Prompter] Core:', () => {
 			]),
 		);
 	});
+
+	it('should always have prompt default value in answers', async () => {
+		const prompter = new Prompter([
+			mkPrompt({
+				name: 'prompt1',
+				default: true,
+			}),
+			mkPrompt({
+				name: 'prompt2',
+				default: 'hey',
+			}),
+		]);
+
+		prompter.setAnswers({ prompt1: false });
+
+		jest.mocked(inquirer.prompt).mockResolvedValue({});
+
+		const answers = await prompter.getAnswers();
+
+		expect(answers).toEqual(
+			expect.objectContaining({
+				prompt1: false,
+				prompt2: 'hey',
+			}),
+		);
+	});
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "templates-mo",
-	"version": "1.2.10",
+	"version": "1.2.11",
 	"description": "Templates is a powerful filesystem generator that aims to simplify the process of getting started with and maintaining code applications",
 	"main": "lib/templates/index.js",
 	"keywords": [

--- a/src/prompter/prompter.ts
+++ b/src/prompter/prompter.ts
@@ -107,9 +107,10 @@ export default class Prompter<TAnswers = AnswersHash> {
 
 	async getAnswers(): Promise<TAnswers> {
 		logger.prompter.info('Fetching answers...');
+		let promptsLeft = this._getPromptsThatNeedAnswers();
+
 		if (!this.needsAnswers()) return this.answers;
 
-		let promptsLeft = this._getPromptsThatNeedAnswers();
 		logger.prompter.info('Current Answers: %n', this.answers);
 		logger.prompter.info(
 			'Prompts that need answers: %n',
@@ -128,6 +129,7 @@ export default class Prompter<TAnswers = AnswersHash> {
 
 			return this.setAnswers(allDefaults);
 		}
+
 		const hiddenPrompts = promptsLeft.filter((prompt) => prompt.hidden);
 
 		// remove hidden prompts if we arent showing them
@@ -161,6 +163,15 @@ export default class Prompter<TAnswers = AnswersHash> {
 			this.setAnswers(allHiddenDefaults);
 		}
 
-		return this.answers;
+		const allDefaults = {};
+		promptsLeft.forEach((prompt) => {
+			// TODO: should default to null
+			allDefaults[prompt.name] = prompt.getDefaultValue({
+				...allDefaults,
+				...this.answers,
+			});
+		});
+
+		return this.setAnswers({ ...allDefaults, ...this.answers });
 	}
 }


### PR DESCRIPTION
## Description

We should always have prompt answers no matter if the user didn't answer them. 

- This allows prompts to default values to env variables
- Allows a default value when a prompt doesn't get prompted due to `when`