### PR TITLE
Files: Simplify Files logic

### DIFF
--- a/__tests__/tests/templates/rendering/core.jest.js
+++ b/__tests__/tests/templates/rendering/core.jest.js
@@ -87,18 +87,47 @@ describe('[Templates] Render Process:', () => {
 		expect(path.join(destPath, 'folder3/folder31')).toBeDirectory();
 	});
 
-	it('should be able to render a local template without tps prefix', async () => {
-		mkTemplate('tps-test-template-prefix');
+	it('should be able to use dynamic files', async () => {
+		const tps = mkTemplate('test-dynamic-file', undefined, {
+			// single extension
+			'./default/index.js.tps': `{{=tps.name}}`,
+			// single extension
+			'./default/file.js.dot': `{{=tps.name}}`,
+			// no extension
+			'./default/.tpsrc.tps': `{{=tps.name}}`,
+			// no extension no dot
+			'./default/settings.tps': `{{=tps.name}}`,
+			// more than one extensions
+			'./default/tps.config.js.tps': `{{=tps.name}}`,
+		});
 
-		const tps = new Templates('test-template-prefix');
+		await tps.render(CWD, ['App']);
 
-		const destPath = playground.pathTo('app');
+		expect(path.join(CWD, 'App/index.js')).toHaveFileContents('App');
+		expect(path.join(CWD, 'App/file.js')).toHaveFileContents('App');
+		expect(path.join(CWD, 'App/.tpsrc')).toHaveFileContents('App');
+		expect(path.join(CWD, 'App/settings')).toHaveFileContents('App');
+		expect(path.join(CWD, 'App/tps.config.js')).toHaveFileContents('App');
+	});
 
-		const results = await tps.render(playground.box(), 'app');
+	it('should be able to use any type of file', async () => {
+		const tps = mkTemplate('test-file', undefined, {
+			// single extension
+			'./default/index.js': 'hey',
+			// no extension
+			'./default/.tpsrc': 'hey',
+			// no extension no dot
+			'./default/settings': 'hey',
+			// more than one extensions
+			'./default/tps.config.js': 'hey',
+		});
 
-		expect(results).toEqual(destPath);
+		await tps.render(CWD, ['App']);
 
-		expect(destPath).toHaveAllFilesAndDirectories(['index.js']);
+		expect(path.join(CWD, 'App/index.js')).toHaveFileContents('hey');
+		expect(path.join(CWD, 'App/.tpsrc')).toHaveFileContents('hey');
+		expect(path.join(CWD, 'App/settings')).toHaveFileContents('hey');
+		expect(path.join(CWD, 'App/tps.config.js')).toHaveFileContents('hey');
 	});
 
 	it('should be able to render a template with nested files and folders', async () => {
@@ -177,6 +206,20 @@ describe('[Templates] Render Process:', () => {
 
 			expect(destPath).toHaveAllFilesAndDirectories(TESTING_PACKAGE_FILES);
 		});
+	});
+
+	it('should be able to render a local template without tps prefix', async () => {
+		mkTemplate('tps-test-template-prefix');
+
+		const tps = new Templates('test-template-prefix');
+
+		const destPath = playground.pathTo('app');
+
+		const results = await tps.render(playground.box(), 'app');
+
+		expect(results).toEqual(destPath);
+
+		expect(destPath).toHaveAllFilesAndDirectories(['index.js']);
 	});
 
 	it('should be able to render a local template with long build path', async () => {

--- a/__tests__/tests/templates/rendering/options/force.jest.ts
+++ b/__tests__/tests/templates/rendering/options/force.jest.ts
@@ -30,7 +30,7 @@ describe('Force', () => {
 		);
 	});
 
-	it('should be able to render a template with force, if files exist', async () => {
+	it.only('should be able to render a template with force, if files exist', async () => {
 		const indexFilePath = path.join(CWD, 'app', 'index.js');
 
 		const files = {

--- a/__tests__/tests/templates/rendering/options/force.jest.ts
+++ b/__tests__/tests/templates/rendering/options/force.jest.ts
@@ -99,7 +99,6 @@ describe('Force', () => {
 
 		vol.writeFileSync(indexFilePath, 'original-file');
 
-		console.log(vol.toTree({ dir: CWD }));
 		await tps.render(CWD, 'app');
 
 		// @ts-expect-error no types for extending jest functions

--- a/__tests__/tests/templates/rendering/options/force.jest.ts
+++ b/__tests__/tests/templates/rendering/options/force.jest.ts
@@ -30,7 +30,7 @@ describe('Force', () => {
 		);
 	});
 
-	it.only('should be able to render a template with force, if files exist', async () => {
+	it('should be able to render a template with force, if files exist', async () => {
 		const indexFilePath = path.join(CWD, 'app', 'index.js');
 
 		const files = {

--- a/__tests__/tests/templates/rendering/options/force.jest.ts
+++ b/__tests__/tests/templates/rendering/options/force.jest.ts
@@ -99,6 +99,7 @@ describe('Force', () => {
 
 		vol.writeFileSync(indexFilePath, 'original-file');
 
+		console.log(vol.toTree({ dir: CWD }));
 		await tps.render(CWD, 'app');
 
 		// @ts-expect-error no types for extending jest functions

--- a/src/errors/dot-error.ts
+++ b/src/errors/dot-error.ts
@@ -3,13 +3,11 @@ import { FileNode } from '@tps/fileSystemTree';
 export class DotError extends Error {
 	public name = 'DotError';
 
-	public fileName: string;
-
-	public path: string;
-
-	constructor(fileNode: FileNode, errorMessage: string) {
-		super(`${errorMessage} ( ${fileNode.path} )`);
-		this.fileName = fileNode.name;
-		this.path = fileNode.path;
+	constructor(
+		public fileName: string,
+		public path: string,
+		errorMessage: string,
+	) {
+		super(`${errorMessage} ( ${path} )`);
 	}
 }

--- a/src/errors/dot-error.ts
+++ b/src/errors/dot-error.ts
@@ -1,5 +1,3 @@
-import { FileNode } from '@tps/fileSystemTree';
-
 export class DotError extends Error {
 	public name = 'DotError';
 

--- a/src/errors/template-errors.ts
+++ b/src/errors/template-errors.ts
@@ -115,14 +115,3 @@ export class BuildError extends Error {
 		);
 	}
 }
-
-export class FileError extends Error {
-	public name = 'FileError';
-
-	constructor(
-		public file: string,
-		public error: Error,
-	) {
-		super(`Failed to create ${file} due to ${error}`);
-	}
-}

--- a/src/errors/template-errors.ts
+++ b/src/errors/template-errors.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import { Build } from '@tps/templates/build';
 import { AnswersHash } from '@tps/types/settings';
 
 export class TemplateNotFoundError extends Error {
@@ -96,5 +97,32 @@ export class GlobalInitializedAlreadyError extends Error {
 	constructor(filePath) {
 		super('tps is already initialized globally initialized');
 		this.path = filePath;
+	}
+}
+
+export class BuildError extends Error {
+	public name = 'BuildError';
+
+	constructor(
+		public buildPath: string,
+		public errors: Error[],
+	) {
+		super(
+			[
+				`Instance failed to get created ${buildPath}:`,
+				errors.map((error) => `- ${error.message}`).join('\n'),
+			].join('\n'),
+		);
+	}
+}
+
+export class FileError extends Error {
+	public name = 'FileError';
+
+	constructor(
+		public file: string,
+		public error: Error,
+	) {
+		super(`Failed to create ${file} due to ${error}`);
 	}
 }

--- a/src/errors/template-errors.ts
+++ b/src/errors/template-errors.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-classes-per-file */
-import { Build } from '@tps/templates/build';
 import { AnswersHash } from '@tps/types/settings';
 
 export class TemplateNotFoundError extends Error {

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -30,29 +30,29 @@ class File {
 	 * @example "nav.css"
 	 * @example ".tpsrc"
 	 */
-	public name: string;
+	public readonly name: string;
 
 	/**
 	 * The directory this file should be in when rendered
 	 *
 	 * @example "./path/to/folder"
 	 */
-	public location: string;
+	public readonly location: string;
 
 	/**
 	 * File should be processed as a dynamic file
 	 */
-	public isDot: boolean = false;
+	public readonly isDot: boolean = false;
 
 	/**
 	 * The templating language engine
 	 */
-	public engine: any;
+	public readonly engine: any;
 
 	/**
 	 * File options
 	 */
-	public options: FileOptions;
+	public readonly options: FileOptions;
 
 	public _dotNameCompiled: dot.RenderFunction;
 
@@ -85,14 +85,14 @@ class File {
 	) {
 		const { dir, base } = path.parse(file);
 
-		this.name = base;
-
 		this.location = dir;
 
 		if (DOT_EXTENTION_MATCH.test(this.name)) {
 			// strip dot extension
 			this.isDot = true;
 			this.name = this.name.replace(DOT_EXTENTION_MATCH, '').trim();
+		} else {
+			this.name = base;
 		}
 
 		this.options = {

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -75,7 +75,7 @@ class File {
 			: dot;
 	}
 
-	fileName(data: Record<string, any> = {}, defs = {}): string {
+	private fileName(data: Record<string, any> = {}, defs = {}): string {
 		let fileName;
 		try {
 			fileName = this.engine.template(this.name, null, defs)(data);
@@ -105,7 +105,7 @@ class File {
 		}
 	}
 
-	async render(
+	public async render(
 		location: string,
 		data: Record<string, any>,
 		defs: any,
@@ -123,7 +123,7 @@ class File {
 		return dest;
 	}
 
-	_addDefaultExtention(name: string): string {
+	private _addDefaultExtention(name: string): string {
 		let fileName = name;
 
 		// Might need to change
@@ -134,11 +134,11 @@ class File {
 		return fileName;
 	}
 
-	_buildParentDir(newDest: string): string {
+	private _buildParentDir(newDest: string): string {
 		return path.join(newDest, this.location);
 	}
 
-	dest(dest: string, data: Record<string, any>, defs: any): string {
+	public dest(dest: string, data: Record<string, any>, defs: any): string {
 		return path.join(this._buildParentDir(dest), this.fileName(data, defs));
 	}
 }

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -3,8 +3,8 @@ import templateEngine from '@tps/templates/template-engine';
 import dot from '@tps/templates/dot';
 import * as path from 'path';
 import fs from 'fs';
-import { DotError } from '@tps/errors';
-import { FileNode } from './fileSystemTree';
+import { DotError, FileError } from '@tps/errors';
+import { FileNode } from '../fileSystemTree';
 
 interface FileOptions {
 	force?: boolean;
@@ -97,24 +97,22 @@ class File {
 		return this._addDefaultExtention(fileName);
 	}
 
-	renderDotFile(dest: string, fileData: string): Promise<string> {
-		return Promise.resolve()
-			.then(() => this.opts.force && fs.promises.rm(dest, { force: true }))
-			.catch((e) => {
-				console.log('this should be force', e);
-			})
-			.then(() => fs.promises.writeFile(dest, fileData, { flag: 'w' }))
+	async render(
+		location: string,
+		data: Record<string, any>,
+		defs: any,
+	): Promise<string> {
+		const dest = this.dest(location, data, defs);
 
-			.then(() => Promise.resolve(dest))
-			.catch((error) => Promise.reject(error));
-	}
-
-	async renderFile(dest: string): Promise<string> {
 		if (this.opts.force) {
 			await fs.promises.rm(dest, { force: true });
 		}
 
-		await fs.promises.writeFile(dest, this.fileData);
+		const fileData = this.isDot
+			? this.fileDataTemplate(data, defs, dest)
+			: this.fileData;
+
+		await fs.promises.writeFile(dest, fileData, { flag: 'w' });
 
 		return dest;
 	}

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -30,24 +30,9 @@ class File {
 
 	public engine: any;
 
-	// public relDirectoryFromPkg: string;
-
 	public opts: FileOptions;
 
 	public _dotNameCompiled: dot.RenderFunction;
-
-	public fileNode: FileNode;
-
-	// public fileData: string;
-
-	public fileDataTemplate: (
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		data: Record<string, any>,
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		defs: any,
-		dest: string,
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	) => any;
 
 	static fromFileNode(fileNode: FileNode, opts: Partial<FileOptions> = {}) {
 		return new File(

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -6,6 +6,9 @@ import fs from 'fs';
 import { DotError } from '@tps/errors';
 import { FileNode } from '../fileSystemTree';
 
+type Defs = Record<string, string>;
+type Data = Record<string, unknown>;
+
 interface FileOptions {
 	force?: boolean;
 	useExperimentalTemplateEngine?: boolean;
@@ -111,7 +114,7 @@ class File {
 	 * @param data - Meta data to pass to the template engine
 	 * @param defs - defs to send to the temnplate engine
 	 */
-	private fileName(data: Record<string, any> = {}, defs = {}): string {
+	private fileName(data: Data = {}, defs: Defs = {}): string {
 		let fileName;
 		try {
 			fileName = this.engine.template(this.name, null, defs)(data);
@@ -131,8 +134,8 @@ class File {
 	 */
 	private async getContents(
 		location: string,
-		data: Record<string, any> = {},
-		defs: Record<string, string> = {},
+		data: Data = {},
+		defs: Defs = {},
 	) {
 		const realData = {
 			...data,
@@ -158,8 +161,8 @@ class File {
 	 */
 	public async render(
 		location: string,
-		data: Record<string, any>,
-		defs: any,
+		data: Data,
+		defs: Defs,
 	): Promise<string> {
 		const dest = this.dest(location, data, defs);
 
@@ -196,7 +199,7 @@ class File {
 	 * @param data - Meta data to pass to the template engine
 	 * @param defs - defs to send to the temnplate engine
 	 */
-	public dest(location: string, data: Record<string, any>, defs: any): string {
+	public dest(location: string, data: Data, defs: Defs): string {
 		return path.join(this._buildParentDir(location), this.fileName(data, defs));
 	}
 }

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -105,6 +105,12 @@ class File {
 			: dot;
 	}
 
+	/**
+	 * Get the final result of the file name for this file. If the name has any
+	 *
+	 * @param data - Meta data to pass to the template engine
+	 * @param defs - defs to send to the temnplate engine
+	 */
 	private fileName(data: Record<string, any> = {}, defs = {}): string {
 		let fileName;
 		try {
@@ -115,6 +121,14 @@ class File {
 		return this._addDefaultExtention(fileName);
 	}
 
+	/**
+	 * Get the file contents for this file. If file is a dynamic file then
+	 * this will be the final result after the template engine process it.
+	 *
+	 * @param location - directory to render this file into
+	 * @param data - Meta data to pass to the template engine
+	 * @param defs - defs to send to the temnplate engine
+	 */
 	private async getContents(
 		location: string,
 		data: Record<string, any> = {},

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -115,13 +115,11 @@ class File {
 	 * @param defs - defs to send to the temnplate engine
 	 */
 	private fileName(data: Data = {}, defs: Defs = {}): string {
-		let fileName;
 		try {
-			fileName = this.engine.template(this.name, null, defs)(data);
+			return this.engine.template(this.name, null, defs)(data);
 		} catch (e) {
 			console.log('file name error', e);
 		}
-		return this._addDefaultExtention(fileName);
 	}
 
 	/**
@@ -175,17 +173,6 @@ class File {
 		await fs.promises.writeFile(dest, contents, { flag: 'w' });
 
 		return dest;
-	}
-
-	private _addDefaultExtention(name: string): string {
-		let fileName = name;
-
-		// Might need to change
-		if (!/\./g.test(name)) {
-			fileName += '.js';
-		}
-
-		return fileName;
 	}
 
 	private _buildParentDir(newDest: string): string {

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -3,7 +3,7 @@ import templateEngine from '@tps/templates/template-engine';
 import dot from '@tps/templates/dot';
 import * as path from 'path';
 import fs from 'fs';
-import { DotError, FileError } from '@tps/errors';
+import { DotError } from '@tps/errors';
 import { FileNode } from '../fileSystemTree';
 
 interface FileOptions {

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -26,7 +26,7 @@ class File {
 
 	public location: string;
 
-	public isDot: boolean;
+	public isDot: boolean = false;
 
 	public engine: any;
 
@@ -157,7 +157,5 @@ class File {
 		return path.join(this._buildParentDir(dest), this.fileName(data, defs));
 	}
 }
-
-File.prototype.isDot = false;
 
 export default File;

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -24,7 +24,7 @@ const DOT_EXTENTION_MATCH = /\.(dot|jst|tps|def)$/i;
 class File {
 	/**
 	 * Name of the file with all extensions. If the name includes a `.tps`, `.def`,
-	 * `.jst`, or `.dot` extension we strip this from the name and mark `isDot` as true
+	 * `.jst`, or `.dot` extension we strip this from the name and mark `isDynamic` as true
 	 *
 	 * @example "index.js"
 	 * @example "nav.css"
@@ -42,7 +42,7 @@ class File {
 	/**
 	 * File should be processed as a dynamic file
 	 */
-	public readonly isDot: boolean = false;
+	public readonly isDynamic: boolean = false;
 
 	/**
 	 * The templating language engine
@@ -85,15 +85,13 @@ class File {
 	) {
 		const { dir, base } = path.parse(file);
 
+		this.isDynamic = DOT_EXTENTION_MATCH.test(base);
+
 		this.location = dir;
 
-		this.name = base;
-
-		if (DOT_EXTENTION_MATCH.test(this.name)) {
-			// strip dot extension
-			this.isDot = true;
-			this.name = this.name.replace(DOT_EXTENTION_MATCH, '').trim();
-		}
+		this.name = this.isDynamic
+			? base.replace(DOT_EXTENTION_MATCH, '').trim()
+			: base;
 
 		this.options = {
 			...DEFAULT_OPTS,
@@ -125,7 +123,7 @@ class File {
 			dest: this.dest(location, data, defs),
 		};
 		try {
-			return this.isDot
+			return this.isDynamic
 				? // How could we cache this here :thinking: this is happening for every dot file
 					this.engine.template(this.contents, null, defs)(realData)
 				: this.contents;

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -52,7 +52,7 @@ class File {
 	/**
 	 * File options
 	 */
-	public readonly options: FileOptions;
+	public options: FileOptions;
 
 	public _dotNameCompiled: dot.RenderFunction;
 
@@ -87,12 +87,12 @@ class File {
 
 		this.location = dir;
 
+		this.name = base;
+
 		if (DOT_EXTENTION_MATCH.test(this.name)) {
 			// strip dot extension
 			this.isDot = true;
 			this.name = this.name.replace(DOT_EXTENTION_MATCH, '').trim();
-		} else {
-			this.name = base;
 		}
 
 		this.options = {

--- a/src/templates/File.ts
+++ b/src/templates/File.ts
@@ -17,10 +17,13 @@ const DEFAULT_OPTS: FileOptions = {
 };
 
 /**
+ * Extensions that should be considered as dynamic files
+ */
+const DYNAMIC_EXTENTION_MATCH = /\.(dot|jst|tps|def)$/i;
+
+/**
  * File
  */
-const DOT_EXTENTION_MATCH = /\.(dot|jst|tps|def)$/i;
-
 class File {
 	/**
 	 * Name of the file with all extensions. If the name includes a `.tps`, `.def`,
@@ -85,12 +88,12 @@ class File {
 	) {
 		const { dir, base } = path.parse(file);
 
-		this.isDynamic = DOT_EXTENTION_MATCH.test(base);
+		this.isDynamic = DYNAMIC_EXTENTION_MATCH.test(base);
 
 		this.location = dir;
 
 		this.name = this.isDynamic
-			? base.replace(DOT_EXTENTION_MATCH, '').trim()
+			? base.replace(DYNAMIC_EXTENTION_MATCH, '').trim()
 			: base;
 
 		this.options = {
@@ -132,6 +135,13 @@ class File {
 		}
 	}
 
+	/**
+	 * Render this file to a specific location
+	 *
+	 * @param location - directory to render this file into
+	 * @param data - Meta data to pass to the template engine
+	 * @param defs - defs to send to the temnplate engine
+	 */
 	public async render(
 		location: string,
 		data: Record<string, any>,
@@ -165,8 +175,15 @@ class File {
 		return path.join(newDest, this.location);
 	}
 
-	public dest(dest: string, data: Record<string, any>, defs: any): string {
-		return path.join(this._buildParentDir(dest), this.fileName(data, defs));
+	/**
+	 * Full destination to render this file to.
+	 *
+	 * @param location - directory to render this file into
+	 * @param data - Meta data to pass to the template engine
+	 * @param defs - defs to send to the temnplate engine
+	 */
+	public dest(location: string, data: Record<string, any>, defs: any): string {
+		return path.join(this._buildParentDir(location), this.fileName(data, defs));
 	}
 }
 

--- a/src/templates/build.ts
+++ b/src/templates/build.ts
@@ -394,7 +394,7 @@ export class Build {
 
 		const results = await Promise.allSettled(
 			this.template.compiledFiles.map(async (file) => {
-				const type = file.isDot ? 'Dot file' : 'File';
+				const type = file.isDynamic ? 'Dynamic File' : 'File';
 				let failed = false;
 
 				try {

--- a/src/templates/build.ts
+++ b/src/templates/build.ts
@@ -385,7 +385,6 @@ export class Build {
 
 	/**
 	 * Creates all files that our template uses in `buildPath` folder
-	 * @param {String} buildPath - destination path to render all files to
 	 * @param {Object} [data={}] - data passed in for dot
 	 */
 	private async renderFiles(data: RenderData): Promise<void> {

--- a/src/templates/build.ts
+++ b/src/templates/build.ts
@@ -308,7 +308,7 @@ export class Build {
 
 		await this.renderDirectories();
 
-		await this.renderFiles(realBuildPath, renderData);
+		await this.renderFiles(renderData);
 
 		loggerGroup.success(
 			`Build Path: %s ${colors.green.italic('(created)')}`,
@@ -388,11 +388,9 @@ export class Build {
 	 * @param {String} buildPath - destination path to render all files to
 	 * @param {Object} [data={}] - data passed in for dot
 	 */
-	private async renderFiles(
-		buildPath: string,
-		data: RenderData,
-	): Promise<void> {
-		const loggerGroup = logger.tps.group(`render_${this.buildPath}`);
+	private async renderFiles(data: RenderData): Promise<void> {
+		const loggerGroup = this.getLogger();
+		const location = this.getDirectory();
 		loggerGroup.info('Rendering files');
 
 		const results = await Promise.allSettled(
@@ -401,7 +399,7 @@ export class Build {
 				let failed = false;
 
 				try {
-					await file.render(this.buildPath, data, this.template.defs);
+					await file.render(location, data, this.template.defs);
 				} catch (error) {
 					failed = true;
 					throw error;

--- a/src/templates/build.ts
+++ b/src/templates/build.ts
@@ -268,7 +268,7 @@ export class Build {
 			// files that already exist get overridden
 			this.template.compiledFiles.forEach((file) => {
 				// eslint-disable-next-line no-param-reassign
-				file.opts.force = true;
+				file.options.force = true;
 			});
 		});
 

--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -6,7 +6,7 @@ import {
 	findTemplate,
 	getTemplateLocations,
 } from '@tps/templates/template-utils';
-import File from '@tps/File';
+import File from '@tps/templates/File';
 import {
 	PackageAlreadyCompiledError,
 	RequiresTemplateError,

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import fs from 'fs';
 import * as is from 'is';
 import { DirNode, FileNode, FileSystemNode } from '@tps/fileSystemTree';
-import File from '@tps/File';
+import File from '@tps/templates/File';
 import * as TPS from '@tps/utilities/constants';
 import {
 	cosmiconfigAllExampleSync,

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -701,7 +701,7 @@ export class Templates<TAnswers extends AnswersHash = AnswersHash> {
 		pkg
 			.find({ type: 'file', ext: { not: '.def' } })
 			.forEach((fileNode: FileNode) => {
-				const file = new File(fileNode, {
+				const file = File.fromFileNode(fileNode, {
 					force,
 					useExperimentalTemplateEngine: this.opts.experimentalTemplateEngine,
 				});


### PR DESCRIPTION
## Description

This PR improves and simplifies the Templates Files logic. 

- Consolidates `renderDotFile` and `renderFile` into `render`
- Remove useless properties that aren't needed
- Support making Files without FileNode
- modernize, add comments, and clean up code
- Moves `File` into template folder
- add unit tests for using different types of files
- add unit tests for using different types of dynamic files

